### PR TITLE
feat: add persistent dark mode

### DIFF
--- a/hophacks-app/app/(tabs)/EventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/EventsScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, ActivityIndicator } from 'react-native';
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 import EventsEventCard, { EventsEventCardProps } from '../../components/Events/EventsEventCard';
 import { getAllEvents } from '../../lib/apiService';
 
@@ -13,6 +14,8 @@ const EventsScreen = () => {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   useEffect(() => {
     fetchEvents();
@@ -59,7 +62,7 @@ const EventsScreen = () => {
   if (loading) {
     return (
       <View style={styles.centerContainer}>
-        <ActivityIndicator size="large" color={Colors.primary} />
+        <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.loadingText}>Loading events...</Text>
       </View>
     );
@@ -102,14 +105,14 @@ const EventsScreen = () => {
 
 export default EventsScreen;
 
-const styles = StyleSheet.create({
+const createStyles = (colors: ColorScheme) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
   },
   centerContainer: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -121,12 +124,12 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 4,
   },
   subtitle: {
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
   },
   eventsContainer: {
     paddingHorizontal: 16,
@@ -138,12 +141,12 @@ const styles = StyleSheet.create({
   },
   loadingText: {
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     marginTop: 12,
   },
   errorText: {
     fontSize: 16,
-    color: Colors.error || '#FF6B6B',
+    color: colors.error || '#FF6B6B',
     textAlign: 'center',
     paddingHorizontal: 20,
   },
@@ -154,12 +157,12 @@ const styles = StyleSheet.create({
   emptyText: {
     fontSize: 18,
     fontWeight: '600',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 8,
   },
   emptySubtext: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     textAlign: 'center',
   },
 });

--- a/hophacks-app/app/(tabs)/GroupsScreen.tsx
+++ b/hophacks-app/app/(tabs)/GroupsScreen.tsx
@@ -1,26 +1,31 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 
-const GroupsScreen = () => (
-  <View style={styles.container}>
-    <Text style={styles.text}>Groups Screen - Coming Soon!</Text>
-  </View>
-);
+const GroupsScreen = () => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Groups Screen - Coming Soon!</Text>
+    </View>
+  );
+};
 
 export default GroupsScreen;
 
-const styles = StyleSheet.create({
+const createStyles = (colors: ColorScheme) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
     justifyContent: 'center',
     alignItems: 'center',
   },
   text: {
     fontSize: 18,
     fontWeight: '600',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     textAlign: 'center',
   },
 });

--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, Alert, ActivityIndicator } from 'react-native'
 import React, { useState, useEffect } from 'react'
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 import { Ionicons } from '@expo/vector-icons';
 import HomeEventCard from '../../components/Home/HomeEventCard';
 import { getUserInfoById } from '@/lib/apiService';
@@ -19,6 +20,8 @@ const HomeScreen = () => {
     tierProgress: 0,
   });
   const [isLoading, setIsLoading] = useState(true);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   // Helper function to determine tier based on points
   const getTierInfo = (points: number) => {
@@ -187,7 +190,7 @@ const HomeScreen = () => {
   // Loading screen component
   const LoadingScreen = () => (
     <View style={styles.loadingContainer}>
-      <ActivityIndicator size="large" color={Colors.primary} />
+      <ActivityIndicator size="large" color={colors.primary} />
       <Text style={styles.loadingText}>Loading your profile...</Text>
     </View>
   );
@@ -201,12 +204,12 @@ const HomeScreen = () => {
       {/* Profile Widget */}
       <View style={styles.profileWidget}>
         <View style={styles.profileIcon}>
-          <Ionicons name="person" size={40} color={Colors.primary} />
+          <Ionicons name="person" size={40} color={colors.primary} />
         </View>
         <View style={styles.profileInfo}>
           <Text style={styles.userName}>{user.name}</Text>
           <View style={styles.streakContainer}>
-            <Ionicons name="flame" size={18} color={Colors.streakActive} />
+            <Ionicons name="flame" size={18} color={colors.streakActive} />
             <Text style={styles.streakText}>{user.streak} week streak</Text>
           </View>
           <Text style={styles.tierText}>{user.currentTier}</Text>
@@ -261,7 +264,7 @@ const HomeScreen = () => {
           {recentActivity.map((activity) => (
             <View key={activity.id} style={styles.activityItem}>
               <View style={styles.activityIcon}>
-                <Ionicons name="checkmark-circle" size={24} color={Colors.success} />
+                <Ionicons name="checkmark-circle" size={24} color={colors.success} />
               </View>
               <View style={styles.activityContent}>
                 <Text style={styles.activityEvent}>{activity.event}</Text>
@@ -283,7 +286,7 @@ const HomeScreen = () => {
       {/* Sign Out Button - For Testing */}
       <View style={styles.signOutSection}>
         <TouchableOpacity style={styles.signOutButton} onPress={handleSignOut}>
-          <Ionicons name="log-out-outline" size={20} color={Colors.error} />
+          <Ionicons name="log-out-outline" size={20} color={colors.error} />
           <Text style={styles.signOutText}>Sign Out (Testing)</Text>
         </TouchableOpacity>
       </View>
@@ -293,33 +296,33 @@ const HomeScreen = () => {
 
 export default HomeScreen;
 
-const styles = StyleSheet.create({
+const createStyles = (colors: ColorScheme) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
   },
   // Loading Screen Styles
   loadingContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
   },
   loadingText: {
     marginTop: 16,
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     fontWeight: '500',
   },
   // Profile Widget Styles
   profileWidget: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     margin: 16,
     padding: 20,
     borderRadius: 16,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 3,
@@ -332,7 +335,7 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: Colors.primaryLight,
+    backgroundColor: colors.primaryLight,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 20,
@@ -343,7 +346,7 @@ const styles = StyleSheet.create({
   userName: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 6,
   },
   streakContainer: {
@@ -354,28 +357,28 @@ const styles = StyleSheet.create({
   streakText: {
     fontSize: 16,
     fontWeight: '600',
-    color: Colors.streakActive,
+    color: colors.streakActive,
     marginLeft: 6,
   },
   tierText: {
     fontSize: 14,
     fontWeight: '500',
-    color: Colors.primary,
+    color: colors.primary,
     marginBottom: 4,
   },
   pointsText: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     fontWeight: '500',
   },
   // Progress Bar Styles
   progressSection: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginBottom: 16,
     padding: 16,
     borderRadius: 12,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 2,
@@ -393,11 +396,11 @@ const styles = StyleSheet.create({
   progressTitle: {
     fontSize: 16,
     fontWeight: '600',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
   },
   progressPoints: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     fontWeight: '500',
   },
   progressBarContainer: {
@@ -407,19 +410,19 @@ const styles = StyleSheet.create({
   progressBarBackground: {
     flex: 1,
     height: 8,
-    backgroundColor: Colors.borderLight,
+    backgroundColor: colors.borderLight,
     borderRadius: 4,
     marginRight: 12,
   },
   progressBarFill: {
     height: '100%',
-    backgroundColor: Colors.primary,
+    backgroundColor: colors.primary,
     borderRadius: 4,
   },
   progressPercentage: {
     fontSize: 14,
     fontWeight: '600',
-    color: Colors.primary,
+    color: colors.primary,
     minWidth: 40,
     textAlign: 'right',
   },
@@ -431,12 +434,12 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 22,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 4,
   },
   sectionSubtitle: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     marginBottom: 16,
   },
   // Event Card Styles
@@ -446,10 +449,10 @@ const styles = StyleSheet.create({
   },
   // Activity Styles
   activityList: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     borderRadius: 12,
     padding: 16,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 2,
@@ -463,7 +466,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 12,
     borderBottomWidth: 1,
-    borderBottomColor: Colors.borderLight,
+    borderBottomColor: colors.borderLight,
   },
   activityIcon: {
     marginRight: 12,
@@ -474,17 +477,17 @@ const styles = StyleSheet.create({
   activityEvent: {
     fontSize: 16,
     fontWeight: '600',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 2,
   },
   activityOrganization: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     marginBottom: 2,
   },
   activityDate: {
     fontSize: 12,
-    color: Colors.textLight,
+    color: colors.textLight,
   },
   activityStats: {
     alignItems: 'flex-end',
@@ -492,16 +495,16 @@ const styles = StyleSheet.create({
   activityPoints: {
     fontSize: 14,
     fontWeight: '600',
-    color: Colors.success,
+    color: colors.success,
     marginBottom: 2,
   },
   activityHours: {
     fontSize: 12,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
   },
   noActivityText: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     textAlign: 'center',
     paddingVertical: 12,
   },
@@ -515,13 +518,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     paddingVertical: 12,
     paddingHorizontal: 20,
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: Colors.error,
-    shadowColor: Colors.shadow,
+    borderColor: colors.error,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 1,
@@ -533,7 +536,7 @@ const styles = StyleSheet.create({
   signOutText: {
     fontSize: 16,
     fontWeight: '600',
-    color: Colors.error,
+    color: colors.error,
     marginLeft: 8,
   },
 });

--- a/hophacks-app/app/(tabs)/MyEventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/MyEventsScreen.tsx
@@ -1,26 +1,30 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { Colors } from '../../constants/colors';
-
-const MyEventsScreen = () => (
-  <View style={styles.container}>
-    <Text style={styles.text}>My Events Screen - Coming Soon!</Text>
-  </View>
-);
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
+const MyEventsScreen = () => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>My Events Screen - Coming Soon!</Text>
+    </View>
+  );
+};
 
 export default MyEventsScreen;
 
-const styles = StyleSheet.create({
+const createStyles = (colors: ColorScheme) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
     justifyContent: 'center',
     alignItems: 'center',
   },
   text: {
     fontSize: 18,
     fontWeight: '600',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     textAlign: 'center',
   },
 });

--- a/hophacks-app/app/(tabs)/ProfileScreen.tsx
+++ b/hophacks-app/app/(tabs)/ProfileScreen.tsx
@@ -11,8 +11,10 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Switch,
 } from 'react-native';
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 import { getCurrentUserProfile, updateUserProfile, updateUserEmail } from '../../lib/apiService';
 import { authService } from '../../lib/authService';
 
@@ -37,6 +39,8 @@ const ProfileScreen = () => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [editMode, setEditMode] = useState(false);
+  const { colors, theme, toggleTheme } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   
   // Form fields (these are the working copies during editing)
   const [displayName, setDisplayName] = useState('');
@@ -173,7 +177,7 @@ const ProfileScreen = () => {
   if (loading) {
     return (
       <View style={[styles.container, styles.centered]}>
-        <ActivityIndicator size="large" color={Colors.primary} />
+        <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.loadingText}>Loading profile...</Text>
       </View>
     );
@@ -210,6 +214,14 @@ const ProfileScreen = () => {
           {renderStatCard('Total Points', profile?.total_points || 0)}
           {renderStatCard('Current Streak', `${profile?.current_streak_weeks || 0} weeks`)}
           {renderStatCard('Longest Streak', `${profile?.longest_streak || 0} weeks`)}
+        </View>
+
+        {/* Theme Section */}
+        <View style={styles.formContainer}>
+          <View style={styles.themeRow}>
+            <Text style={styles.inputLabel}>Dark Mode</Text>
+            <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
+          </View>
         </View>
 
         {/* Profile Form */}
@@ -295,7 +307,7 @@ const ProfileScreen = () => {
               disabled={saving}
             >
               {saving ? (
-                <ActivityIndicator color={Colors.textWhite} />
+                <ActivityIndicator color={colors.textWhite} />
               ) : (
                 <Text style={styles.saveButtonText}>Save Changes</Text>
               )}
@@ -309,10 +321,10 @@ const ProfileScreen = () => {
 
 export default ProfileScreen;
 
-const styles = StyleSheet.create({
+const createStyles = (colors: ColorScheme) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: colors.background,
   },
   centered: {
     justifyContent: 'center',
@@ -324,15 +336,15 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 16,
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
   },
   header: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     padding: 20,
     flexDirection: 'row',
     alignItems: 'center',
     borderBottomWidth: 1,
-    borderBottomColor: Colors.border,
+    borderBottomColor: colors.border,
   },
   headerInfo: {
     flex: 1,
@@ -340,33 +352,33 @@ const styles = StyleSheet.create({
   displayName: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 4,
   },
   role: {
     fontSize: 16,
-    color: Colors.primary,
+    color: colors.primary,
     marginBottom: 4,
     textTransform: 'capitalize',
   },
   memberSince: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
   },
   editButton: {
-    backgroundColor: Colors.primary,
+    backgroundColor: colors.primary,
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
   },
   editButtonText: {
-    color: Colors.textWhite,
+    color: colors.textWhite,
     fontSize: 14,
     fontWeight: '600',
   },
   statsContainer: {
     flexDirection: 'row',
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginTop: 1,
     paddingVertical: 20,
   },
@@ -378,23 +390,23 @@ const styles = StyleSheet.create({
   statValue: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: Colors.primary,
+    color: colors.primary,
     marginBottom: 4,
   },
   statLabel: {
     fontSize: 12,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     textAlign: 'center',
   },
   formContainer: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginTop: 1,
     padding: 20,
   },
   sectionTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 20,
     marginTop: 16,
   },
@@ -404,22 +416,22 @@ const styles = StyleSheet.create({
   inputLabel: {
     fontSize: 14,
     fontWeight: '600',
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     marginBottom: 8,
   },
   input: {
     borderWidth: 1,
-    borderColor: Colors.border,
+    borderColor: colors.border,
     borderRadius: 8,
     paddingHorizontal: 16,
     paddingVertical: 12,
     fontSize: 16,
-    color: Colors.textPrimary,
-    backgroundColor: Colors.surface,
+    color: colors.textPrimary,
+    backgroundColor: colors.surface,
   },
   inputDisabled: {
-    backgroundColor: Colors.surfaceSecondary,
-    color: Colors.textSecondary,
+    backgroundColor: colors.surfaceSecondary,
+    color: colors.textSecondary,
   },
   textArea: {
     minHeight: 80,
@@ -427,11 +439,11 @@ const styles = StyleSheet.create({
   },
   inputHint: {
     fontSize: 12,
-    color: Colors.textLight,
+    color: colors.textLight,
     marginTop: 4,
   },
   saveButton: {
-    backgroundColor: Colors.primary,
+    backgroundColor: colors.primary,
     borderRadius: 8,
     paddingVertical: 16,
     marginTop: 24,
@@ -441,8 +453,14 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   saveButtonText: {
-    color: Colors.textWhite,
+    color: colors.textWhite,
     fontSize: 16,
     fontWeight: '600',
+  },
+  themeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
   },
 });

--- a/hophacks-app/app/_layout.tsx
+++ b/hophacks-app/app/_layout.tsx
@@ -1,12 +1,15 @@
 import { Stack } from "expo-router";
+import { ThemeProvider } from "../context/ThemeContext";
 
 export default function RootLayout() {
   return (
-    <Stack>
-      <Stack.Screen 
-        name="index" 
-        options={{ headerShown: false }} 
-      />
-    </Stack>
+    <ThemeProvider>
+      <Stack>
+        <Stack.Screen
+          name="index"
+          options={{ headerShown: false }}
+        />
+      </Stack>
+    </ThemeProvider>
   );
 }

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Text, View, StyleSheet, SafeAreaView, ActivityIndicator } from "react-native";
+import { StatusBar } from 'expo-status-bar';
 import CustomTabBar from '../components/CustomTabBar';
-import { Colors } from '../constants/colors';
+import { useTheme } from '../context/ThemeContext';
+import type { ColorScheme } from '../constants/colors';
 import HomeScreen from './(tabs)/HomeScreen';
 import EventsScreen from './(tabs)/EventsScreen';
 import MyEventsScreen from './(tabs)/MyEventsScreen';
@@ -12,6 +14,8 @@ import { authService } from '../lib/authService';
 export default function Index() {
   const [activeTab, setActiveTab] = useState('home');
   const [isInitializing, setIsInitializing] = useState(true);
+  const { colors, theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   useEffect(() => {
     console.log('Initializing app...');
@@ -60,7 +64,7 @@ export default function Index() {
   if (isInitializing) {
     return (
       <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={Colors.primary} />
+        <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.loadingText}>Initializing app...</Text>
       </View>
     );
@@ -68,6 +72,7 @@ export default function Index() {
 
   return (
     <View style={styles.container}>
+      <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.background} />
       <SafeAreaView style={styles.safeArea}>
         {renderTabContent()}
       </SafeAreaView>
@@ -76,36 +81,37 @@ export default function Index() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
-  safeArea: {
-    flex: 1,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: Colors.background,
-  },
-  loadingText: {
-    marginTop: 16,
-    fontSize: 16,
-    color: Colors.textSecondary,
-    fontWeight: '500',
-  },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 20,
-  },
-  tabContent: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-});
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    safeArea: {
+      flex: 1,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: colors.background,
+    },
+    loadingText: {
+      marginTop: 16,
+      fontSize: 16,
+      color: colors.textSecondary,
+      fontWeight: '500',
+    },
+    content: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: 20,
+    },
+    tabContent: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      textAlign: 'center',
+    },
+  });

--- a/hophacks-app/components/CustomTabBar.tsx
+++ b/hophacks-app/components/CustomTabBar.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Animated, Dimensions } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { Colors } from '../constants/colors';
+import { useTheme } from '../context/ThemeContext';
+import type { ColorScheme } from '../constants/colors';
 
 interface TabBarProps {
   activeTab: string;
@@ -11,6 +12,8 @@ interface TabBarProps {
 const CustomTabBar: React.FC<TabBarProps> = ({ activeTab, onTabPress }) => {
   const animatedValue = useRef(new Animated.Value(0)).current;
   const { width: screenWidth } = Dimensions.get('window');
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   
   const tabs = [
     {
@@ -82,7 +85,7 @@ const CustomTabBar: React.FC<TabBarProps> = ({ activeTab, onTabPress }) => {
             <Ionicons
               name={activeTab === tab.id ? tab.activeIcon : tab.icon}
               size={20}
-              color={activeTab === tab.id ? Colors.textWhite : Colors.tabBarInactive}
+              color={activeTab === tab.id ? colors.textWhite : colors.tabBarInactive}
             />
           </View>
           <Text style={[
@@ -97,59 +100,60 @@ const CustomTabBar: React.FC<TabBarProps> = ({ activeTab, onTabPress }) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    backgroundColor: Colors.tabBarBackground,
-    borderTopWidth: 1,
-    borderTopColor: Colors.tabBarBorder,
-    paddingBottom: 36,
-    paddingTop: 6,
-    paddingHorizontal: 4,
-    shadowColor: Colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: -2,
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      backgroundColor: colors.tabBarBackground,
+      borderTopWidth: 1,
+      borderTopColor: colors.tabBarBorder,
+      paddingBottom: 36,
+      paddingTop: 6,
+      paddingHorizontal: 4,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: -2,
+      },
+      shadowOpacity: 0.1,
+      shadowRadius: 3,
+      elevation: 5,
+      position: 'relative',
     },
-    shadowOpacity: 0.1,
-    shadowRadius: 3,
-    elevation: 5,
-    position: 'relative',
-  },
-  animatedIndicator: {
-    position: 'absolute',
-    top: 10, // Adjusted to align with icon container
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: Colors.primary,
-    zIndex: 1,
-  },
-  tabButton: {
-    flex: 1,
-    alignItems: 'center',
-    paddingVertical: 4,
-    paddingHorizontal: 4,
-    zIndex: 2, // Ensure tabs are above the indicator
-  },
-  iconContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: 2,
-  },
-  tabLabel: {
-    fontSize: 10,
-    fontWeight: '500',
-    color: Colors.tabBarInactive,
-    textAlign: 'center',
-  },
-  activeLabel: {
-    color: Colors.tabBarActive,
-    fontWeight: '600',
-  },
-});
+    animatedIndicator: {
+      position: 'absolute',
+      top: 10, // Adjusted to align with icon container
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.primary,
+      zIndex: 1,
+    },
+    tabButton: {
+      flex: 1,
+      alignItems: 'center',
+      paddingVertical: 4,
+      paddingHorizontal: 4,
+      zIndex: 2, // Ensure tabs are above the indicator
+    },
+    iconContainer: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: 2,
+    },
+    tabLabel: {
+      fontSize: 10,
+      fontWeight: '500',
+      color: colors.tabBarInactive,
+      textAlign: 'center',
+    },
+    activeLabel: {
+      color: colors.tabBarActive,
+      fontWeight: '600',
+    },
+  });
 
 export default CustomTabBar;

--- a/hophacks-app/components/EventCallToActionButton.tsx
+++ b/hophacks-app/components/EventCallToActionButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-import { Colors } from '../constants/colors';
+import { useTheme } from '../context/ThemeContext';
+import type { ColorScheme } from '../constants/colors';
 import SpecificEventPage from './SpecificEventPage';
 
 export interface EventCallToActionButtonProps {
@@ -17,6 +18,8 @@ const EventCallToActionButton: React.FC<EventCallToActionButtonProps> = ({
   style,
 }) => {
   const [showEventDetails, setShowEventDetails] = useState(false);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   const handlePress = () => {
     if (onPress) {
@@ -30,7 +33,7 @@ const EventCallToActionButton: React.FC<EventCallToActionButtonProps> = ({
   return (
     <>
       <TouchableOpacity 
-        style={[styles.button, disabled && styles.buttonDisabled, style]} 
+        style={[styles.button, disabled && styles.buttonDisabled, style]}
         onPress={handlePress}
         disabled={disabled}
         activeOpacity={0.8}
@@ -51,24 +54,25 @@ const EventCallToActionButton: React.FC<EventCallToActionButtonProps> = ({
 
 export default EventCallToActionButton;
 
-const styles = StyleSheet.create({
-  button: {
-    backgroundColor: Colors.primary,
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    borderRadius: 8,
-    alignItems: 'center',
-  },
-  buttonDisabled: {
-    backgroundColor: Colors.textSecondary || '#999999',
-    opacity: 0.6,
-  },
-  buttonText: {
-    color: Colors.textWhite,
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  buttonTextDisabled: {
-    color: Colors.textSecondary || '#999999',
-  },
-});
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    button: {
+      backgroundColor: colors.primary,
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+      alignItems: 'center',
+    },
+    buttonDisabled: {
+      backgroundColor: colors.textSecondary || '#999999',
+      opacity: 0.6,
+    },
+    buttonText: {
+      color: colors.textWhite,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    buttonTextDisabled: {
+      color: colors.textSecondary || '#999999',
+    },
+  });

--- a/hophacks-app/components/Events/EventsEventCard.tsx
+++ b/hophacks-app/components/Events/EventsEventCard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 import EventCallToActionButton from '../EventCallToActionButton';
 
 // Interface for EventsScreen event cards (full-width, detailed view)
@@ -36,6 +37,9 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
   onPress,
   showJoinButton = true,
 }) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
   // Format date/time for display
   const formatEventTime = (startTime: string, endTime: string) => {
     const start = new Date(startTime);
@@ -77,7 +81,7 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
       <View style={styles.eventHeader}>
         {/* Event Image Placeholder */}
         <View style={styles.eventImageContainer}>
-          <Ionicons name="image-outline" size={32} color={Colors.textSecondary} />
+          <Ionicons name="image-outline" size={32} color={colors.textSecondary} />
         </View>
         
         {/* Event Info */}
@@ -95,21 +99,21 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
       
       <View style={styles.eventDetails}>
         <View style={styles.eventDetailItem}>
-          <Ionicons name="location-outline" size={14} color={Colors.textSecondary} />
+          <Ionicons name="location-outline" size={14} color={colors.textSecondary} />
           <Text style={styles.eventDetailText}>{getLocationText()}</Text>
         </View>
         <View style={styles.eventDetailItem}>
-          <Ionicons name="pricetag-outline" size={14} color={Colors.textSecondary} />
+          <Ionicons name="pricetag-outline" size={14} color={colors.textSecondary} />
           <Text style={styles.eventDetailText}>{formatCause(cause)}</Text>
         </View>
         {capacity && (
           <View style={styles.eventDetailItem}>
-            <Ionicons name="people-outline" size={14} color={Colors.textSecondary} />
+            <Ionicons name="people-outline" size={14} color={colors.textSecondary} />
             <Text style={styles.eventDetailText}>Cap: {capacity}</Text>
           </View>
         )}
         <View style={styles.eventDetailItem}>
-          <Ionicons name="time-outline" size={14} color={Colors.textSecondary} />
+          <Ionicons name="time-outline" size={14} color={colors.textSecondary} />
           <Text style={styles.eventDetailText}>{formatEventTime(starts_at, ends_at)}</Text>
         </View>
       </View>
@@ -123,66 +127,67 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
 
 export default EventsEventCard;
 
-const styles = StyleSheet.create({
-  eventCard: {
-    backgroundColor: Colors.surface,
-    borderRadius: 12,
-    padding: 16,
-    width: '100%',
-    shadowColor: Colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 2,
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    eventCard: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: 16,
+      width: '100%',
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 2,
+      },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
     },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  eventHeader: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    marginBottom: 12,
-  },
-  eventImageContainer: {
-    width: 60,
-    height: 60,
-    borderRadius: 8,
-    backgroundColor: Colors.borderLight || '#E5E5E5',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 12,
-  },
-  eventInfo: {
-    flex: 1,
-    justifyContent: 'flex-start',
-  },
-  eventTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.textPrimary,
-    marginBottom: 4,
-  },
-  eventOrganization: {
-    fontSize: 14,
-    color: Colors.textSecondary,
-  },
-  eventDescription: {
-    fontSize: 13,
-    color: Colors.textSecondary,
-    marginBottom: 12,
-    lineHeight: 18,
-  },
-  eventDetails: {
-    marginBottom: 16,
-  },
-  eventDetailItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  eventDetailText: {
-    fontSize: 12,
-    color: Colors.textSecondary,
-    marginLeft: 6,
-  },
-});
+    eventHeader: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginBottom: 12,
+    },
+    eventImageContainer: {
+      width: 60,
+      height: 60,
+      borderRadius: 8,
+      backgroundColor: colors.borderLight || '#E5E5E5',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginRight: 12,
+    },
+    eventInfo: {
+      flex: 1,
+      justifyContent: 'flex-start',
+    },
+    eventTitle: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      marginBottom: 4,
+    },
+    eventOrganization: {
+      fontSize: 14,
+      color: colors.textSecondary,
+    },
+    eventDescription: {
+      fontSize: 13,
+      color: colors.textSecondary,
+      marginBottom: 12,
+      lineHeight: 18,
+    },
+    eventDetails: {
+      marginBottom: 16,
+    },
+    eventDetailItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    eventDetailText: {
+      fontSize: 12,
+      color: colors.textSecondary,
+      marginLeft: 6,
+    },
+  });

--- a/hophacks-app/components/Home/HomeEventCard.tsx
+++ b/hophacks-app/components/Home/HomeEventCard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { Colors } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
 import EventCallToActionButton from '../EventCallToActionButton';
 
 // Interface for HomeScreen event cards (compact, horizontal scrolling)
@@ -36,6 +37,9 @@ const HomeEventCard: React.FC<HomeEventCardProps> = ({
   onPress,
   showJoinButton = true,
 }) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
   // Format date/time for display
   const formatEventTime = (startTime: string, endTime: string) => {
     const start = new Date(startTime);
@@ -83,11 +87,11 @@ const HomeEventCard: React.FC<HomeEventCardProps> = ({
       
       <View style={styles.eventDetails}>
         <View style={styles.eventDetailItem}>
-          <Ionicons name="location-outline" size={14} color={Colors.textSecondary} />
+          <Ionicons name="location-outline" size={14} color={colors.textSecondary} />
           <Text style={styles.eventDetailText}>{getLocationText()}</Text>
         </View>
         <View style={styles.eventDetailItem}>
-          <Ionicons name="pricetag-outline" size={14} color={Colors.textSecondary} />
+          <Ionicons name="pricetag-outline" size={14} color={colors.textSecondary} />
           <Text style={styles.eventDetailText}>{formatCause(cause)}</Text>
         </View>
       </View>
@@ -101,56 +105,57 @@ const HomeEventCard: React.FC<HomeEventCardProps> = ({
 
 export default HomeEventCard;
 
-const styles = StyleSheet.create({
-  eventCard: {
-    backgroundColor: Colors.surface,
-    borderRadius: 12,
-    padding: 16,
-    marginRight: 12,
-    width: 280,
-    shadowColor: Colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 2,
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    eventCard: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: 16,
+      marginRight: 12,
+      width: 280,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 2,
+      },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
     },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  eventHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: 8,
-  },
-  eventTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.textPrimary,
-    flex: 1,
-    marginRight: 8,
-  },
-  eventTime: {
-    fontSize: 12,
-    color: Colors.primary,
-    fontWeight: '500',
-  },
-  eventOrganization: {
-    fontSize: 14,
-    color: Colors.textSecondary,
-    marginBottom: 12,
-  },
-  eventDetails: {
-    marginBottom: 16,
-  },
-  eventDetailItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  eventDetailText: {
-    fontSize: 12,
-    color: Colors.textSecondary,
-    marginLeft: 6,
-  },
-});
+    eventHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: 8,
+    },
+    eventTitle: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      flex: 1,
+      marginRight: 8,
+    },
+    eventTime: {
+      fontSize: 12,
+      color: colors.primary,
+      fontWeight: '500',
+    },
+    eventOrganization: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      marginBottom: 12,
+    },
+    eventDetails: {
+      marginBottom: 16,
+    },
+    eventDetailItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    eventDetailText: {
+      fontSize: 12,
+      color: colors.textSecondary,
+      marginLeft: 6,
+    },
+  });

--- a/hophacks-app/components/SpecificEventPage.tsx
+++ b/hophacks-app/components/SpecificEventPage.tsx
@@ -11,7 +11,7 @@ import {
   Modal,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { Colors } from '../constants/colors';
+import { lightColors as colors } from '../constants/colors';
 import { getEventById } from '../lib/apiService';
 
 interface EventDetail {
@@ -120,7 +120,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
     if (loading) {
       return (
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={Colors.primary} />
+          <ActivityIndicator size="large" color={colors.primary} />
           <Text style={styles.loadingText}>Loading event details...</Text>
         </View>
       );
@@ -129,7 +129,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
     if (error || !event) {
       return (
         <View style={styles.errorContainer}>
-          <Ionicons name="alert-circle-outline" size={48} color={Colors.textSecondary} />
+          <Ionicons name="alert-circle-outline" size={48} color={colors.textSecondary} />
           <Text style={styles.errorText}>{error || 'Event not found'}</Text>
           <TouchableOpacity style={styles.backButton} onPress={onClose}>
             <Text style={styles.backButtonText}>Go Back</Text>
@@ -145,7 +145,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
           {/* Event Image Banner */}
           <View style={styles.bannerContainer}>
             <View style={styles.imagePlaceholder}>
-              <Ionicons name="calendar" size={56} color={Colors.primary} style={styles.placeholderIcon} />
+              <Ionicons name="calendar" size={56} color={colors.primary} style={styles.placeholderIcon} />
               <Text style={styles.placeholderText}>Event Image</Text>
             </View>
             
@@ -177,7 +177,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
             <Text style={styles.organizationName}>
               {event.organizations?.name || 'Organization'}
               {event.organizations?.verified && (
-                <Ionicons name="checkmark-circle" size={16} color={Colors.primary} style={styles.verifiedIcon} />
+                <Ionicons name="checkmark-circle" size={16} color={colors.primary} style={styles.verifiedIcon} />
               )}
             </Text>
           </View>
@@ -185,7 +185,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
           {/* Key Event Details */}
           <View style={styles.detailsCard}>
             <View style={styles.detailRow}>
-              <Ionicons name="location" size={24} color={Colors.primary} style={styles.detailIcon} />
+              <Ionicons name="location" size={24} color={colors.primary} style={styles.detailIcon} />
               <View style={styles.detailContent}>
                 <Text style={styles.detailLabel}>Location</Text>
                 <Text style={styles.detailValue}>{getLocationText()}</Text>
@@ -195,7 +195,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
             <View style={styles.detailDivider} />
 
             <View style={styles.detailRow}>
-              <Ionicons name="pricetag" size={24} color={Colors.primary} style={styles.detailIcon} />
+              <Ionicons name="pricetag" size={24} color={colors.primary} style={styles.detailIcon} />
               <View style={styles.detailContent}>
                 <Text style={styles.detailLabel}>Category</Text>
                 <Text style={styles.detailValue}>{formatCause(event.cause)}</Text>
@@ -206,7 +206,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
               <>
                 <View style={styles.detailDivider} />
                 <View style={styles.detailRow}>
-                  <Ionicons name="people" size={24} color={Colors.primary} style={styles.detailIcon} />
+                  <Ionicons name="people" size={24} color={colors.primary} style={styles.detailIcon} />
                   <View style={styles.detailContent}>
                     <Text style={styles.detailLabel}>Capacity</Text>
                     <Text style={styles.detailValue}>Cap: {event.capacity} people</Text>
@@ -218,7 +218,7 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
             <View style={styles.detailDivider} />
 
             <View style={styles.detailRow}>
-              <Ionicons name="time" size={24} color={Colors.primary} style={styles.detailIcon} />
+              <Ionicons name="time" size={24} color={colors.primary} style={styles.detailIcon} />
               <View style={styles.detailContent}>
                 <Text style={styles.detailLabel}>Date & Time</Text>
                 <Text style={styles.detailValue}>{formatEventTime(event.starts_at, event.ends_at)}</Text>
@@ -278,7 +278,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 16,
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
   },
   errorContainer: {
     flex: 1,
@@ -290,18 +290,18 @@ const styles = StyleSheet.create({
   errorText: {
     marginTop: 16,
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     textAlign: 'center',
   },
   errorBackButton: {
     marginTop: 20,
     paddingHorizontal: 20,
     paddingVertical: 10,
-    backgroundColor: Colors.primary,
+    backgroundColor: colors.primary,
     borderRadius: 8,
   },
   backButtonText: {
-    color: Colors.textWhite,
+    color: colors.textWhite,
     fontSize: 16,
     fontWeight: '600',
   },
@@ -329,7 +329,7 @@ const styles = StyleSheet.create({
   placeholderText: {
     fontSize: 16,
     fontWeight: '500',
-    color: Colors.primary,
+    color: colors.primary,
     opacity: 0.8,
   },
   navButton: {
@@ -363,12 +363,12 @@ const styles = StyleSheet.create({
     paddingBottom: 120, // Space for sticky button
   },
   mainInfoCard: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginHorizontal: 20,
     marginTop: -16,
     borderRadius: 20,
     padding: 24,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 8,
@@ -381,13 +381,13 @@ const styles = StyleSheet.create({
   eventTitle: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     marginBottom: 8,
     lineHeight: 34,
   },
   organizationName: {
     fontSize: 18,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     fontWeight: '500',
     flexDirection: 'row',
     alignItems: 'center',
@@ -396,12 +396,12 @@ const styles = StyleSheet.create({
     marginLeft: 6,
   },
   detailsCard: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginHorizontal: 20,
     marginTop: 20,
     borderRadius: 20,
     padding: 24,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 4,
@@ -425,7 +425,7 @@ const styles = StyleSheet.create({
   },
   detailLabel: {
     fontSize: 14,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     fontWeight: '500',
     marginBottom: 4,
     textTransform: 'uppercase',
@@ -433,23 +433,23 @@ const styles = StyleSheet.create({
   },
   detailValue: {
     fontSize: 17,
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
     fontWeight: '600',
     lineHeight: 22,
   },
   detailDivider: {
     height: 1,
-    backgroundColor: Colors.border || '#E5E5E5',
+    backgroundColor: colors.border || '#E5E5E5',
     marginVertical: 4,
     marginLeft: 40, // Align with content, not icons
   },
   descriptionCard: {
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     marginHorizontal: 20,
     marginTop: 20,
     borderRadius: 20,
     padding: 24,
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: 4,
@@ -462,16 +462,16 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     paddingBottom: 12,
     borderBottomWidth: 2,
-    borderBottomColor: Colors.primary,
+    borderBottomColor: colors.primary,
   },
   descriptionHeading: {
     fontSize: 22,
     fontWeight: 'bold',
-    color: Colors.textPrimary,
+    color: colors.textPrimary,
   },
   descriptionText: {
     fontSize: 16,
-    color: Colors.textSecondary,
+    color: colors.textSecondary,
     lineHeight: 24,
     fontWeight: '400',
   },
@@ -483,11 +483,11 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: Colors.surface,
+    backgroundColor: colors.surface,
     paddingHorizontal: 20,
     paddingTop: 16,
     paddingBottom: 40, // Safe area for iOS home bar
-    shadowColor: Colors.shadow,
+    shadowColor: colors.shadow,
     shadowOffset: {
       width: 0,
       height: -4,
@@ -497,11 +497,11 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
   joinButton: {
-    backgroundColor: Colors.primary,
+    backgroundColor: colors.primary,
     paddingVertical: 18,
     borderRadius: 16,
     alignItems: 'center',
-    shadowColor: Colors.primary,
+    shadowColor: colors.primary,
     shadowOffset: {
       width: 0,
       height: 4,
@@ -511,7 +511,7 @@ const styles = StyleSheet.create({
     elevation: 6,
   },
   joinButtonText: {
-    color: Colors.textWhite,
+    color: colors.textWhite,
     fontSize: 20,
     fontWeight: 'bold',
     letterSpacing: 0.5,

--- a/hophacks-app/components/SpecificEventPage.tsx
+++ b/hophacks-app/components/SpecificEventPage.tsx
@@ -11,7 +11,8 @@ import {
   Modal,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { lightColors as colors } from '../constants/colors';
+import { ColorScheme } from '../constants/colors';
+import { useTheme } from '../context/ThemeContext';
 import { getEventById } from '../lib/apiService';
 
 interface EventDetail {
@@ -44,6 +45,8 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
   visible,
   onClose,
 }) => {
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -264,258 +267,259 @@ const SpecificEventPage: React.FC<SpecificEventPageProps> = ({
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#F8F8F8',
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F8F8F8',
-  },
-  loadingText: {
-    marginTop: 16,
-    fontSize: 16,
-    color: colors.textSecondary,
-  },
-  errorContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F8F8F8',
-    paddingHorizontal: 20,
-  },
-  errorText: {
-    marginTop: 16,
-    fontSize: 16,
-    color: colors.textSecondary,
-    textAlign: 'center',
-  },
-  errorBackButton: {
-    marginTop: 20,
-    paddingHorizontal: 20,
-    paddingVertical: 10,
-    backgroundColor: colors.primary,
-    borderRadius: 8,
-  },
-  backButtonText: {
-    color: colors.textWhite,
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  headerContainer: {
-    position: 'relative',
-  },
-  bannerContainer: {
-    height: 240,
-    backgroundColor: '#F0F0F0',
-    position: 'relative',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-  },
-  imagePlaceholder: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-    borderRadius: 16,
-    margin: 16,
-  },
-  placeholderIcon: {
-    marginBottom: 8,
-  },
-  placeholderText: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: colors.primary,
-    opacity: 0.8,
-  },
-  navButton: {
-    position: 'absolute',
-    top: 50,
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 4,
+const getStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
     },
-    shadowOpacity: 0.15,
-    shadowRadius: 8,
-    elevation: 6,
-  },
-  backButton: {
-    left: 20,
-  },
-  shareButton: {
-    right: 20,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingBottom: 120, // Space for sticky button
-  },
-  mainInfoCard: {
-    backgroundColor: colors.surface,
-    marginHorizontal: 20,
-    marginTop: -16,
-    borderRadius: 20,
-    padding: 24,
-    shadowColor: colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 8,
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: colors.background,
     },
-    shadowOpacity: 0.12,
-    shadowRadius: 16,
-    elevation: 8,
-    zIndex: 1,
-  },
-  eventTitle: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
-    marginBottom: 8,
-    lineHeight: 34,
-  },
-  organizationName: {
-    fontSize: 18,
-    color: colors.textSecondary,
-    fontWeight: '500',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  verifiedIcon: {
-    marginLeft: 6,
-  },
-  detailsCard: {
-    backgroundColor: colors.surface,
-    marginHorizontal: 20,
-    marginTop: 20,
-    borderRadius: 20,
-    padding: 24,
-    shadowColor: colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 4,
+    loadingText: {
+      marginTop: 16,
+      fontSize: 16,
+      color: colors.textSecondary,
     },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 4,
-  },
-  detailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-  },
-  detailIcon: {
-    marginRight: 16,
-    width: 24,
-    textAlign: 'center',
-  },
-  detailContent: {
-    flex: 1,
-  },
-  detailLabel: {
-    fontSize: 14,
-    color: colors.textSecondary,
-    fontWeight: '500',
-    marginBottom: 4,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  detailValue: {
-    fontSize: 17,
-    color: colors.textPrimary,
-    fontWeight: '600',
-    lineHeight: 22,
-  },
-  detailDivider: {
-    height: 1,
-    backgroundColor: colors.border || '#E5E5E5',
-    marginVertical: 4,
-    marginLeft: 40, // Align with content, not icons
-  },
-  descriptionCard: {
-    backgroundColor: colors.surface,
-    marginHorizontal: 20,
-    marginTop: 20,
-    borderRadius: 20,
-    padding: 24,
-    shadowColor: colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 4,
+    errorContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: colors.background,
+      paddingHorizontal: 20,
     },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 4,
-  },
-  sectionHeader: {
-    marginBottom: 16,
-    paddingBottom: 12,
-    borderBottomWidth: 2,
-    borderBottomColor: colors.primary,
-  },
-  descriptionHeading: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
-  },
-  descriptionText: {
-    fontSize: 16,
-    color: colors.textSecondary,
-    lineHeight: 24,
-    fontWeight: '400',
-  },
-  bottomSpacing: {
-    height: 40,
-  },
-  stickyButtonContainer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: colors.surface,
-    paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 40, // Safe area for iOS home bar
-    shadowColor: colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: -4,
+    errorText: {
+      marginTop: 16,
+      fontSize: 16,
+      color: colors.textSecondary,
+      textAlign: 'center',
     },
-    shadowOpacity: 0.15,
-    shadowRadius: 12,
-    elevation: 8,
-  },
-  joinButton: {
-    backgroundColor: colors.primary,
-    paddingVertical: 18,
-    borderRadius: 16,
-    alignItems: 'center',
-    shadowColor: colors.primary,
-    shadowOffset: {
-      width: 0,
-      height: 4,
+    errorBackButton: {
+      marginTop: 20,
+      paddingHorizontal: 20,
+      paddingVertical: 10,
+      backgroundColor: colors.primary,
+      borderRadius: 8,
     },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 6,
-  },
-  joinButtonText: {
-    color: colors.textWhite,
-    fontSize: 20,
-    fontWeight: 'bold',
-    letterSpacing: 0.5,
-  },
-});
+    backButtonText: {
+      color: colors.textWhite,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    headerContainer: {
+      position: 'relative',
+    },
+    bannerContainer: {
+      height: 240,
+      backgroundColor: colors.surfaceSecondary,
+      position: 'relative',
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+    },
+    imagePlaceholder: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      borderRadius: 16,
+      margin: 16,
+    },
+    placeholderIcon: {
+      marginBottom: 8,
+    },
+    placeholderText: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: colors.primary,
+      opacity: 0.8,
+    },
+    navButton: {
+      position: 'absolute',
+      top: 50,
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: 'rgba(255, 255, 255, 0.95)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      shadowColor: '#000',
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: 0.15,
+      shadowRadius: 8,
+      elevation: 6,
+    },
+    backButton: {
+      left: 20,
+    },
+    shareButton: {
+      right: 20,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    scrollContent: {
+      paddingBottom: 120, // Space for sticky button
+    },
+    mainInfoCard: {
+      backgroundColor: colors.surface,
+      marginHorizontal: 20,
+      marginTop: -16,
+      borderRadius: 20,
+      padding: 24,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 8,
+      },
+      shadowOpacity: 0.12,
+      shadowRadius: 16,
+      elevation: 8,
+      zIndex: 1,
+    },
+    eventTitle: {
+      fontSize: 28,
+      fontWeight: 'bold',
+      color: colors.textPrimary,
+      marginBottom: 8,
+      lineHeight: 34,
+    },
+    organizationName: {
+      fontSize: 18,
+      color: colors.textSecondary,
+      fontWeight: '500',
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    verifiedIcon: {
+      marginLeft: 6,
+    },
+    detailsCard: {
+      backgroundColor: colors.surface,
+      marginHorizontal: 20,
+      marginTop: 20,
+      borderRadius: 20,
+      padding: 24,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: 0.08,
+      shadowRadius: 12,
+      elevation: 4,
+    },
+    detailRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+    },
+    detailIcon: {
+      marginRight: 16,
+      width: 24,
+      textAlign: 'center',
+    },
+    detailContent: {
+      flex: 1,
+    },
+    detailLabel: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      fontWeight: '500',
+      marginBottom: 4,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    detailValue: {
+      fontSize: 17,
+      color: colors.textPrimary,
+      fontWeight: '600',
+      lineHeight: 22,
+    },
+    detailDivider: {
+      height: 1,
+      backgroundColor: colors.border || '#E5E5E5',
+      marginVertical: 4,
+      marginLeft: 40, // Align with content, not icons
+    },
+    descriptionCard: {
+      backgroundColor: colors.surface,
+      marginHorizontal: 20,
+      marginTop: 20,
+      borderRadius: 20,
+      padding: 24,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: 0.08,
+      shadowRadius: 12,
+      elevation: 4,
+    },
+    sectionHeader: {
+      marginBottom: 16,
+      paddingBottom: 12,
+      borderBottomWidth: 2,
+      borderBottomColor: colors.primary,
+    },
+    descriptionHeading: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      color: colors.textPrimary,
+    },
+    descriptionText: {
+      fontSize: 16,
+      color: colors.textSecondary,
+      lineHeight: 24,
+      fontWeight: '400',
+    },
+    bottomSpacing: {
+      height: 40,
+    },
+    stickyButtonContainer: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: colors.surface,
+      paddingHorizontal: 20,
+      paddingTop: 16,
+      paddingBottom: 40, // Safe area for iOS home bar
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: -4,
+      },
+      shadowOpacity: 0.15,
+      shadowRadius: 12,
+      elevation: 8,
+    },
+    joinButton: {
+      backgroundColor: colors.primary,
+      paddingVertical: 18,
+      borderRadius: 16,
+      alignItems: 'center',
+      shadowColor: colors.primary,
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: 0.3,
+      shadowRadius: 8,
+      elevation: 6,
+    },
+    joinButtonText: {
+      color: colors.textWhite,
+      fontSize: 20,
+      fontWeight: 'bold',
+      letterSpacing: 0.5,
+    },
+  });
 
 export default SpecificEventPage;

--- a/hophacks-app/constants/colors.ts
+++ b/hophacks-app/constants/colors.ts
@@ -1,55 +1,55 @@
-export const Colors = {
+export const lightColors = {
   // Primary Colors
   primary: '#FF6B35',
   primaryLight: '#FFF5F0',
   primaryDark: '#E55A2B',
-  
+
   // Background Colors
   background: '#F8F9FA',
   surface: '#FFFFFF',
   surfaceSecondary: '#F5F5F5',
-  
+
   // Text Colors
   textPrimary: '#333333',
   textSecondary: '#666666',
   textLight: '#999999',
   textWhite: '#FFFFFF',
-  
+
   // Border Colors
   border: '#E5E5E5',
   borderLight: '#F0F0F0',
-  
+
   // Status Colors
   success: '#4CAF50',
   warning: '#FF9800',
   error: '#F44336',
   info: '#2196F3',
-  
+
   // Tab Bar Colors
   tabBarBackground: '#FFFFFF',
   tabBarBorder: '#E5E5E5',
   tabBarActive: '#FF6B35',
   tabBarInactive: '#666666',
-  
+
   // Shadow Colors
   shadow: '#000000',
-  
+
   // Group/Competition Colors
   groupGold: '#FFD700',
   groupSilver: '#C0C0C0',
   groupBronze: '#CD7F32',
-  
+
   // Event Category Colors
   foodSecurity: '#4CAF50',
   animalWelfare: '#9C27B0',
   elderCare: '#FF9800',
   environment: '#4CAF50',
   education: '#2196F3',
-  
+
   // Streak Colors
   streakActive: '#FF6B35',
   streakInactive: '#CCCCCC',
-  
+
   // Badge Colors
   badgeGold: '#FFD700',
   badgeSilver: '#C0C0C0',
@@ -57,4 +57,67 @@ export const Colors = {
   badgePlatinum: '#E5E4E2',
 } as const;
 
-export type ColorKey = keyof typeof Colors;
+export const darkColors: typeof lightColors = {
+  // Primary Colors
+  primary: '#FF6B35',
+  primaryLight: '#E55A2B',
+  primaryDark: '#FFF5F0',
+
+  // Background Colors
+  background: '#121212',
+  surface: '#1E1E1E',
+  surfaceSecondary: '#2C2C2C',
+
+  // Text Colors
+  textPrimary: '#F5F5F5',
+  textSecondary: '#CCCCCC',
+  textLight: '#999999',
+  textWhite: '#FFFFFF',
+
+  // Border Colors
+  border: '#333333',
+  borderLight: '#444444',
+
+  // Status Colors
+  success: '#4CAF50',
+  warning: '#FF9800',
+  error: '#F44336',
+  info: '#2196F3',
+
+  // Tab Bar Colors
+  tabBarBackground: '#1E1E1E',
+  tabBarBorder: '#333333',
+  tabBarActive: '#FF6B35',
+  tabBarInactive: '#999999',
+
+  // Shadow Colors
+  shadow: '#000000',
+
+  // Group/Competition Colors
+  groupGold: '#FFD700',
+  groupSilver: '#C0C0C0',
+  groupBronze: '#CD7F32',
+
+  // Event Category Colors
+  foodSecurity: '#4CAF50',
+  animalWelfare: '#9C27B0',
+  elderCare: '#FF9800',
+  environment: '#4CAF50',
+  education: '#2196F3',
+
+  // Streak Colors
+  streakActive: '#FF6B35',
+  streakInactive: '#666666',
+
+  // Badge Colors
+  badgeGold: '#FFD700',
+  badgeSilver: '#C0C0C0',
+  badgeBronze: '#CD7F32',
+  badgePlatinum: '#E5E4E2',
+};
+
+export type ColorScheme = typeof lightColors;
+
+export const getThemeColors = (theme: 'light' | 'dark'): ColorScheme =>
+  theme === 'dark' ? darkColors : lightColors;
+

--- a/hophacks-app/context/ThemeContext.tsx
+++ b/hophacks-app/context/ThemeContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useColorScheme } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SystemUI from 'expo-system-ui';
+import { getThemeColors, ColorScheme } from '../constants/colors';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  colors: ColorScheme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const systemTheme = useColorScheme() ?? 'light';
+  const [theme, setTheme] = useState<Theme>(systemTheme);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const loadTheme = async () => {
+      try {
+        const stored = await AsyncStorage.getItem('theme');
+        if (stored === 'light' || stored === 'dark') {
+          setTheme(stored);
+        } else {
+          setTheme(systemTheme);
+        }
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+    loadTheme();
+  }, [systemTheme]);
+
+  const colors = getThemeColors(theme);
+
+  useEffect(() => {
+    SystemUI.setBackgroundColorAsync(colors.background);
+  }, [colors.background]);
+
+  const toggleTheme = async () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    await AsyncStorage.setItem('theme', next);
+  };
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- support light/dark color palettes and theme helper
- introduce ThemeProvider and wrap app to supply colors
- add dark mode switch on profile screen and refactor screens/components for theme-aware styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c569119be88333bfef2aa36d841d3b