### PR TITLE
Use system theme without manual toggle

### DIFF
--- a/hophacks-app/app/(tabs)/ProfileScreen.tsx
+++ b/hophacks-app/app/(tabs)/ProfileScreen.tsx
@@ -11,7 +11,6 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
-  Switch,
 } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import type { ColorScheme } from '../../constants/colors';
@@ -39,7 +38,7 @@ const ProfileScreen = () => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const { colors, theme, toggleTheme } = useTheme();
+  const { colors } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
   
   // Form fields (these are the working copies during editing)
@@ -214,14 +213,6 @@ const ProfileScreen = () => {
           {renderStatCard('Total Points', profile?.total_points || 0)}
           {renderStatCard('Current Streak', `${profile?.current_streak_weeks || 0} weeks`)}
           {renderStatCard('Longest Streak', `${profile?.longest_streak || 0} weeks`)}
-        </View>
-
-        {/* Theme Section */}
-        <View style={styles.formContainer}>
-          <View style={styles.themeRow}>
-            <Text style={styles.inputLabel}>Dark Mode</Text>
-            <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
-          </View>
         </View>
 
         {/* Profile Form */}
@@ -456,11 +447,5 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     color: colors.textWhite,
     fontSize: 16,
     fontWeight: '600',
-  },
-  themeRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 16,
   },
 });

--- a/hophacks-app/context/ThemeContext.tsx
+++ b/hophacks-app/context/ThemeContext.tsx
@@ -1,6 +1,5 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 import { useColorScheme } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SystemUI from 'expo-system-ui';
 import { getThemeColors, ColorScheme } from '../constants/colors';
 
@@ -9,50 +8,20 @@ type Theme = 'light' | 'dark';
 interface ThemeContextType {
   theme: Theme;
   colors: ColorScheme;
-  toggleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const systemTheme = useColorScheme() ?? 'light';
-  const [theme, setTheme] = useState<Theme>(systemTheme);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
-    const loadTheme = async () => {
-      try {
-        const stored = await AsyncStorage.getItem('theme');
-        if (stored === 'light' || stored === 'dark') {
-          setTheme(stored);
-        } else {
-          setTheme(systemTheme);
-        }
-      } finally {
-        setIsLoaded(true);
-      }
-    };
-    loadTheme();
-  }, [systemTheme]);
-
+  const theme = useColorScheme() ?? 'light';
   const colors = getThemeColors(theme);
 
   useEffect(() => {
     SystemUI.setBackgroundColorAsync(colors.background);
   }, [colors.background]);
 
-  const toggleTheme = async () => {
-    const next = theme === 'light' ? 'dark' : 'light';
-    setTheme(next);
-    await AsyncStorage.setItem('theme', next);
-  };
-
-  if (!isLoaded) {
-    return null;
-  }
-
   return (
-    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, colors }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- simplify ThemeProvider to follow system color scheme and drop stored preference
- remove dark mode switch from profile screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5908c2de88333a41238ab1320ba8f