### PR TITLE
Implement login flow with sign up and profile sign out

### DIFF
--- a/hophacks-app/Schema.txt
+++ b/hophacks-app/Schema.txt
@@ -63,7 +63,7 @@ CREATE TABLE public.joins (
   check_out_by uuid,
   check_in_geog USER-DEFINED,
   check_out_geog USER-DEFINED,
-  minutes integer,
+  minutes integer CHECK (minutes IS NULL OR minutes >= 0),
   points_awarded integer,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   CONSTRAINT joins_pkey PRIMARY KEY (id),
@@ -134,3 +134,4 @@ CREATE TABLE public.user_badges (
   CONSTRAINT user_badges_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.profiles(id),
   CONSTRAINT user_badges_badge_id_fkey FOREIGN KEY (badge_id) REFERENCES public.badges(id)
 );
+

--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -1,11 +1,10 @@
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, Alert, ActivityIndicator } from 'react-native'
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native'
 import React, { useState, useEffect } from 'react'
 import { useTheme } from '../../context/ThemeContext';
 import type { ColorScheme } from '../../constants/colors';
 import { Ionicons } from '@expo/vector-icons';
 import HomeEventCard from '../../components/Home/HomeEventCard';
 import { getUserInfoById, getEventRecommendations } from '@/lib/apiService';
-import { authService } from '../../lib/authService';
 
 const HomeScreen = () => {
   // Mock data - replace with real data later
@@ -71,12 +70,12 @@ const HomeScreen = () => {
 
         // Fetch user data
         const { data: userData, error: userError } = await getUserInfoById();
-        
+
         if (userError) {
           console.log('Error fetching user:', userError);
         } else if (userData) {
           const tierInfo = getTierInfo(userData.total_points || 0);
-          
+
           setUser({
             name: userData.display_name || "Volunteer",
             streak: userData.current_streak_weeks || 0,
@@ -90,7 +89,7 @@ const HomeScreen = () => {
 
         // Fetch event recommendations
         const { data: eventsData, error: eventsError } = await getEventRecommendations();
-        
+
         if (eventsError) {
           console.log('Error fetching events:', eventsError);
         } else if (eventsData) {
@@ -116,35 +115,9 @@ const HomeScreen = () => {
         setIsLoading(false);
       }
     };
-    
+
     fetchUserAndEvents();
   }, []);
-
-  const handleSignOut = async () => {
-    Alert.alert(
-      "Sign Out",
-      "Are you sure you want to sign out?",
-      [
-        {
-          text: "Cancel",
-          style: "cancel"
-        },
-        {
-          text: "Sign Out",
-          style: "destructive",
-          onPress: async () => {
-            try {
-              await authService.signOut();
-              console.log('User signed out successfully');
-              // You could add navigation logic here if needed
-            } catch (error) {
-              console.log('Error signing out:', error);
-            }
-          }
-        }
-      ]
-    );
-  };
 
   const recentActivity = [
     {
@@ -264,12 +237,6 @@ const HomeScreen = () => {
       </View>
 
       {/* Sign Out Button - For Testing */}
-      <View style={styles.signOutSection}>
-        <TouchableOpacity style={styles.signOutButton} onPress={handleSignOut}>
-          <Ionicons name="log-out-outline" size={20} color={colors.error} />
-          <Text style={styles.signOutText}>Sign Out (Testing)</Text>
-        </TouchableOpacity>
-      </View>
     </ScrollView>
   )
 }
@@ -489,34 +456,4 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     paddingVertical: 12,
   },
   // Sign Out Button Styles
-  signOutSection: {
-    marginHorizontal: 16,
-    marginBottom: 24,
-    marginTop: 16,
-  },
-  signOutButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.surface,
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: colors.error,
-    shadowColor: colors.shadow,
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
-  },
-  signOutText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.error,
-    marginLeft: 8,
-  },
 });

--- a/hophacks-app/app/(tabs)/ProfileScreen.tsx
+++ b/hophacks-app/app/(tabs)/ProfileScreen.tsx
@@ -13,6 +13,7 @@ import {
   Platform,
   Switch,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../context/ThemeContext';
 import type { ColorScheme } from '../../constants/colors';
 import { getCurrentUserProfile, updateUserProfile, updateUserEmail } from '../../lib/apiService';
@@ -33,7 +34,11 @@ interface Profile {
   created_at: string;
 }
 
-const ProfileScreen = () => {
+interface ProfileScreenProps {
+  onSignOut: () => void;
+}
+
+const ProfileScreen: React.FC<ProfileScreenProps> = ({ onSignOut }) => {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [email, setEmail] = useState<string>('');
   const [loading, setLoading] = useState(true);
@@ -165,6 +170,28 @@ const ProfileScreen = () => {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleSignOut = () => {
+    Alert.alert(
+      'Sign Out',
+      'Are you sure you want to sign out?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Sign Out',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await authService.signOut();
+              onSignOut();
+            } catch (error) {
+              console.log('Error signing out:', error);
+            }
+          },
+        },
+      ],
+    );
   };
 
   const renderStatCard = (label: string, value: number | string, icon?: string) => (
@@ -306,13 +333,20 @@ const ProfileScreen = () => {
               onPress={handleSave}
               disabled={saving}
             >
-              {saving ? (
-                <ActivityIndicator color={colors.textWhite} />
-              ) : (
-                <Text style={styles.saveButtonText}>Save Changes</Text>
-              )}
-            </TouchableOpacity>
+          {saving ? (
+            <ActivityIndicator color={colors.textWhite} />
+          ) : (
+            <Text style={styles.saveButtonText}>Save Changes</Text>
           )}
+        </TouchableOpacity>
+      )}
+    </View>
+
+        <View style={styles.signOutSection}>
+          <TouchableOpacity style={styles.signOutButton} onPress={handleSignOut}>
+            <Ionicons name="log-out-outline" size={20} color={colors.error} />
+            <Text style={styles.signOutText}>Sign Out</Text>
+          </TouchableOpacity>
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
@@ -462,5 +496,25 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     marginBottom: 16,
+  },
+  signOutSection: {
+    marginTop: 24,
+    marginHorizontal: 20,
+  },
+  signOutButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.surface,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.error,
+  },
+  signOutText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.error,
+    marginLeft: 8,
   },
 });

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -10,10 +10,12 @@ import MyEventsScreen from './(tabs)/MyEventsScreen';
 import GroupsScreen from './(tabs)/GroupsScreen';
 import ProfileScreen from './(tabs)/ProfileScreen';
 import { authService } from '../lib/authService';
+import LoginScreen from '../components/Auth/LoginScreen';
 
 export default function Index() {
   const [activeTab, setActiveTab] = useState('home');
   const [isInitializing, setIsInitializing] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const { colors, theme } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
 
@@ -23,11 +25,11 @@ export default function Index() {
       try {
         console.log('Initializing authentication...');
         const authSuccess = await authService.initializeAuth();
-        
+        setIsAuthenticated(authSuccess);
         if (authSuccess) {
           console.log('App initialized successfully');
         } else {
-          console.log('Authentication failed, but continuing with app');
+          console.log('No existing session, showing login screen');
         }
       } catch (error) {
         console.log('App initialization error:', error);
@@ -55,7 +57,7 @@ export default function Index() {
       case 'groups':
         return <GroupsScreen />;
       case 'profile':
-        return <ProfileScreen />;
+        return <ProfileScreen onSignOut={() => setIsAuthenticated(false)} />;
       default:
         return <HomeScreen />;
     }
@@ -68,6 +70,10 @@ export default function Index() {
         <Text style={styles.loadingText}>Initializing app...</Text>
       </View>
     );
+  }
+
+  if (!isAuthenticated) {
+    return <LoginScreen onAuthSuccess={() => setIsAuthenticated(true)} />;
   }
 
   return (

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -73,7 +73,14 @@ export default function Index() {
   }
 
   if (!isAuthenticated) {
-    return <LoginScreen onAuthSuccess={() => setIsAuthenticated(true)} />;
+    return (
+      <LoginScreen
+        onAuthSuccess={() => {
+          setIsAuthenticated(true);
+          setActiveTab('home');
+        }}
+      />
+    );
   }
 
   return (

--- a/hophacks-app/components/Auth/LoginScreen.tsx
+++ b/hophacks-app/components/Auth/LoginScreen.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
+import { authService } from '../../lib/authService';
+
+interface LoginScreenProps {
+  onAuthSuccess: () => void;
+}
+
+const LoginScreen: React.FC<LoginScreenProps> = ({ onAuthSuccess }) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const [mode, setMode] = useState<'signIn' | 'signUp'>('signIn');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result =
+        mode === 'signIn'
+          ? await authService.signIn(email, password)
+          : await authService.signUp(email, password);
+
+      if (result.success) {
+        onAuthSuccess();
+      } else if (result.error) {
+        setError(result.error);
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>
+        {mode === 'signIn' ? 'Sign In' : 'Create Account'}
+      </Text>
+      {error && <Text style={styles.errorText}>{error}</Text>}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      <TouchableOpacity
+        style={styles.button}
+        onPress={handleSubmit}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={colors.textWhite} />
+        ) : (
+          <Text style={styles.buttonText}>
+            {mode === 'signIn' ? 'Sign In' : 'Sign Up'}
+          </Text>
+        )}
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={() =>
+          setMode(mode === 'signIn' ? 'signUp' : 'signIn')
+        }
+      >
+        <Text style={styles.switchText}>
+          {mode === 'signIn'
+            ? "Don't have an account? Sign up"
+            : 'Already have an account? Sign in'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default LoginScreen;
+
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      padding: 24,
+      backgroundColor: colors.background,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      textAlign: 'center',
+      marginBottom: 24,
+      color: colors.textPrimary,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+      padding: 12,
+      marginBottom: 12,
+      color: colors.textPrimary,
+      backgroundColor: colors.surface,
+    },
+    button: {
+      backgroundColor: colors.primary,
+      padding: 16,
+      borderRadius: 8,
+      alignItems: 'center',
+      marginTop: 8,
+      marginBottom: 16,
+    },
+    buttonText: {
+      color: colors.textWhite,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    switchText: {
+      color: colors.primary,
+      textAlign: 'center',
+    },
+    errorText: {
+      color: colors.error,
+      textAlign: 'center',
+      marginBottom: 8,
+    },
+  });


### PR DESCRIPTION
## Summary
- require authentication on app load with new login screen that supports account creation
- move sign out control to profile tab and clean up home tab
- add reusable auth service helpers and update schema documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5917f09a08333ac45e40c6a66a167