### PR TITLE
Improve avatar readability in dark mode

### DIFF
--- a/hophacks-app/app/(tabs)/GroupsScreen.tsx
+++ b/hophacks-app/app/(tabs)/GroupsScreen.tsx
@@ -378,7 +378,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 8,
@@ -386,7 +386,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
   avatarText: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.primary,
+    color: colors.textWhite,
   },
   topMemberName: {
     fontSize: 14,

--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -218,7 +218,9 @@ const HomeScreen = () => {
       {/* Profile Widget */}
       <View style={styles.profileWidget}>
         <View style={styles.profileIcon}>
-          <Ionicons name="person" size={40} color={colors.primary} />
+          <Text style={styles.profileIconText}>
+            {user.name.charAt(0).toUpperCase()}
+          </Text>
         </View>
         <View style={styles.profileInfo}>
           <Text style={styles.userName}>{user.name}</Text>
@@ -378,10 +380,15 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 20,
+  },
+  profileIconText: {
+    fontSize: 32,
+    fontWeight: '600',
+    color: colors.textWhite,
   },
   profileInfo: {
     flex: 1,

--- a/hophacks-app/app/activity-feed.tsx
+++ b/hophacks-app/app/activity-feed.tsx
@@ -158,7 +158,7 @@ const ActivityFeedScreen = () => {
           <View style={styles.emptyContainer}>
             <Ionicons name="time-outline" size={64} color={colors.textSecondary} />
             <Text style={styles.emptyTitle}>No Activity Yet</Text>
-            <Text style={styles.emptySubtitle}>Group members haven't completed any activities recently.</Text>
+              <Text style={styles.emptySubtitle}>Group members haven&apos;t completed any activities recently.</Text>
           </View>
         ) : (
           activities.map((activity) => (

--- a/hophacks-app/app/group-dashboard/[id].tsx
+++ b/hophacks-app/app/group-dashboard/[id].tsx
@@ -420,7 +420,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginHorizontal: 12,
@@ -428,7 +428,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
   avatarText: {
     fontSize: 16,
     fontWeight: '600',
-    color: colors.primary,
+    color: colors.textWhite,
   },
   memberInfo: {
     flex: 1,
@@ -486,7 +486,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 16,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginLeft: -8,
@@ -496,7 +496,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
   clusterAvatarText: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.primary,
+    color: colors.textWhite,
   },
   moreAvatars: {
     width: 32,

--- a/hophacks-app/app/leaderboard.tsx
+++ b/hophacks-app/app/leaderboard.tsx
@@ -190,7 +190,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginHorizontal: 16,
@@ -198,7 +198,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
   avatarText: {
     fontSize: 18,
     fontWeight: '600',
-    color: colors.primary,
+    color: colors.textWhite,
   },
   memberInfo: {
     flex: 1,

--- a/hophacks-app/app/members.tsx
+++ b/hophacks-app/app/members.tsx
@@ -346,7 +346,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: colors.primaryLight,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 16,
@@ -354,7 +354,7 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
   avatarText: {
     fontSize: 18,
     fontWeight: '600',
-    color: colors.primary,
+    color: colors.textWhite,
   },
   memberInfo: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Show user's initial instead of generic person icon on home screen
- Use primary color with white text for user avatars across the app for better dark mode contrast
- Escape apostrophe in activity feed to satisfy linter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c59be06f6c83339be2f6b9d4e3448b