### PR TITLE
Limit home event titles to two lines

### DIFF
--- a/hophacks-app/app/activity-feed.tsx
+++ b/hophacks-app/app/activity-feed.tsx
@@ -158,7 +158,7 @@ const ActivityFeedScreen = () => {
           <View style={styles.emptyContainer}>
             <Ionicons name="time-outline" size={64} color={colors.textSecondary} />
             <Text style={styles.emptyTitle}>No Activity Yet</Text>
-            <Text style={styles.emptySubtitle}>Group members haven't completed any activities recently.</Text>
+              <Text style={styles.emptySubtitle}>Group members haven&apos;t completed any activities recently.</Text>
           </View>
         ) : (
           activities.map((activity) => (

--- a/hophacks-app/components/Home/HomeEventCard.tsx
+++ b/hophacks-app/components/Home/HomeEventCard.tsx
@@ -79,7 +79,13 @@ const HomeEventCard: React.FC<HomeEventCardProps> = ({
       activeOpacity={0.8}
     >
       <View style={styles.eventHeader}>
-        <Text style={styles.eventTitle}>{title}</Text>
+        <Text
+          style={styles.eventTitle}
+          numberOfLines={2}
+          ellipsizeMode="tail"
+        >
+          {title}
+        </Text>
         <Text style={styles.eventTime}>{formatEventTime(starts_at, ends_at)}</Text>
       </View>
       


### PR DESCRIPTION
## Summary
- prevent long recommended event titles from expanding beyond two lines with an ellipsis
- escape apostrophe in activity feed empty state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c59c2c6a248333b1893c9e4ec34244