### PR TITLE
Add QR code scanning for event attendance

### DIFF
--- a/hophacks-app/app/(tabs)/MyEventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/MyEventsScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, ScrollView, ActivityIndicator } from 'react-nat
 import { useTheme } from '../../context/ThemeContext';
 import type { ColorScheme } from '../../constants/colors';
 import EventsEventCard, { EventsEventCardProps } from '../../components/Events/EventsEventCard';
+import QRScannerModal from '../../components/Events/QRScannerModal';
 import SpecificEventPage from '../../components/SpecificEventPage';
 import { getJoinedEvents } from '../../lib/apiService';
 
@@ -22,6 +23,7 @@ const MyEventsScreen = () => {
   const [error, setError] = useState<string | null>(null);
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [eventPageVisible, setEventPageVisible] = useState(false);
+  const [scannerVisible, setScannerVisible] = useState(false);
 
   useEffect(() => {
     fetchJoinedEvents();
@@ -57,6 +59,8 @@ const MyEventsScreen = () => {
             capacity: event.capacity,
             org_name: event.organizations?.name || 'Unknown Organization',
             distance: event.lat && event.lng ? 'Near you' : 'Location TBD',
+            checkInTime: join.check_in_at,
+            checkOutTime: join.check_out_at,
             onPress: undefined,
             showLearnMoreButton: false,
           };
@@ -129,6 +133,10 @@ const MyEventsScreen = () => {
                     {...event}
                     onPress={() => openEvent(event.id)}
                     showLearnMoreButton={false}
+                    showScanButton={new Date(event.ends_at) >= new Date()}
+                    onScanPress={() => setScannerVisible(true)}
+                    checkInTime={new Date(event.ends_at) < new Date() ? event.checkInTime : undefined}
+                    checkOutTime={new Date(event.ends_at) < new Date() ? event.checkOutTime : undefined}
                   />
                 </View>
               ))}
@@ -150,6 +158,12 @@ const MyEventsScreen = () => {
           onJoinSuccess={closeEvent}
         />
       )}
+
+      <QRScannerModal
+        visible={scannerVisible}
+        onClose={() => setScannerVisible(false)}
+        onSuccess={fetchJoinedEvents}
+      />
     </>
   );
 };

--- a/hophacks-app/components/Events/EventsEventCard.tsx
+++ b/hophacks-app/components/Events/EventsEventCard.tsx
@@ -20,6 +20,10 @@ export interface EventsEventCardProps {
   distance?: string;
   onPress?: () => void;
   showLearnMoreButton?: boolean;
+  onScanPress?: () => void;
+  showScanButton?: boolean;
+  checkInTime?: string;
+  checkOutTime?: string;
 }
 
 const EventsEventCard: React.FC<EventsEventCardProps> = ({
@@ -36,6 +40,10 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
   distance = 'Location TBD',
   onPress,
   showLearnMoreButton = true,
+  onScanPress,
+  showScanButton = false,
+  checkInTime,
+  checkOutTime,
 }) => {
   const { colors } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
@@ -71,6 +79,9 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
     }
     return distance;
   };
+
+  const formatTimeOnly = (time: string) =>
+    new Date(time).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 
   return (
     <TouchableOpacity 
@@ -118,10 +129,30 @@ const EventsEventCard: React.FC<EventsEventCardProps> = ({
         </View>
       </View>
       
-      {showLearnMoreButton && (
-        <TouchableOpacity style={styles.learnMoreButton} onPress={onPress} activeOpacity={0.8}>
-          <Text style={styles.learnMoreButtonText}>Learn More</Text>
-        </TouchableOpacity>
+      {(checkInTime || checkOutTime) && (
+        <View style={styles.attendanceTimes}>
+          {checkInTime && (
+            <Text style={styles.attendanceText}>Sign in: {formatTimeOnly(checkInTime)}</Text>
+          )}
+          {checkOutTime && (
+            <Text style={styles.attendanceText}>Sign out: {formatTimeOnly(checkOutTime)}</Text>
+          )}
+        </View>
+      )}
+
+      {(showLearnMoreButton || showScanButton) && (
+        <View style={styles.buttonRow}>
+          {showLearnMoreButton && (
+            <TouchableOpacity style={styles.learnMoreButton} onPress={onPress} activeOpacity={0.8}>
+              <Text style={styles.learnMoreButtonText}>Learn More</Text>
+            </TouchableOpacity>
+          )}
+          {showScanButton && (
+            <TouchableOpacity style={styles.scanButton} onPress={onScanPress} activeOpacity={0.8}>
+              <Ionicons name="qr-code-outline" size={20} color={colors.textWhite} />
+            </TouchableOpacity>
+          )}
+        </View>
       )}
     </TouchableOpacity>
   );
@@ -192,6 +223,19 @@ const createStyles = (colors: ColorScheme) =>
       color: colors.textSecondary,
       marginLeft: 6,
     },
+    attendanceTimes: {
+      marginBottom: 12,
+    },
+    attendanceText: {
+      fontSize: 12,
+      color: colors.warning,
+      marginBottom: 4,
+    },
+    buttonRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
     learnMoreButton: {
       backgroundColor: colors.primary,
       paddingVertical: 8,
@@ -203,5 +247,10 @@ const createStyles = (colors: ColorScheme) =>
       color: colors.textWhite,
       fontSize: 14,
       fontWeight: '600',
+    },
+    scanButton: {
+      backgroundColor: colors.primary,
+      padding: 8,
+      borderRadius: 8,
     },
   });

--- a/hophacks-app/components/Events/QRScannerModal.tsx
+++ b/hophacks-app/components/Events/QRScannerModal.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, StyleSheet, Switch, TouchableOpacity, Alert } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
+import { checkInToEvent, checkOutFromEvent } from '../../lib/apiService';
+
+interface QRScannerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuccess }) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [isSignIn, setIsSignIn] = useState(true);
+  const [scanned, setScanned] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setScanned(false);
+      BarCodeScanner.requestPermissionsAsync().then(({ status }) =>
+        setHasPermission(status === 'granted')
+      );
+    }
+  }, [visible]);
+
+  const handleBarCodeScanned = async ({ data }: { data: string }) => {
+    if (scanned) return;
+    setScanned(true);
+    const eventId = data;
+    const result = isSignIn ? await checkInToEvent(eventId) : await checkOutFromEvent(eventId);
+
+    if (result.error) {
+      Alert.alert('Error', result.error.message || 'Unable to update attendance');
+    } else {
+      Alert.alert('Success', isSignIn ? 'Checked in successfully' : 'Checked out successfully');
+      onSuccess && onSuccess();
+    }
+    onClose();
+  };
+
+  if (hasPermission === null) return null;
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        {hasPermission ? (
+          <BarCodeScanner
+            style={StyleSheet.absoluteFillObject}
+            onBarCodeScanned={handleBarCodeScanned}
+          />
+        ) : (
+          <View style={styles.permissionContainer}>
+            <Text style={styles.permissionText}>Camera permission is required</Text>
+          </View>
+        )}
+        <View style={styles.controls}>
+          <View style={styles.toggleContainer}>
+            <Text style={styles.toggleLabel}>{isSignIn ? 'Sign In' : 'Sign Out'}</Text>
+            <Switch value={isSignIn} onValueChange={setIsSignIn} />
+          </View>
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <Text style={styles.closeButtonText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default QRScannerModal;
+
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    controls: {
+      position: 'absolute',
+      bottom: 40,
+      left: 0,
+      right: 0,
+      alignItems: 'center',
+    },
+    toggleContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 16,
+    },
+    toggleLabel: {
+      color: colors.textWhite,
+      fontSize: 16,
+      marginRight: 8,
+    },
+    closeButton: {
+      backgroundColor: colors.primary,
+      paddingVertical: 10,
+      paddingHorizontal: 20,
+      borderRadius: 8,
+    },
+    closeButtonText: {
+      color: colors.textWhite,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    permissionContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    permissionText: {
+      color: colors.textPrimary,
+    },
+  });

--- a/hophacks-app/package-lock.json
+++ b/hophacks-app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.8",
         "@supabase/supabase-js": "^2.57.4",
         "expo": "~54.0.6",
+        "expo-barcode-scanner": "~13.0.1",
         "expo-constants": "~18.0.8",
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
@@ -8602,6 +8603,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-barcode-scanner": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-13.0.1.tgz",
+      "integrity": "sha512-xBGLT1An2gpAMIQRTLU3oHydKohX8r8F9/ait1Fk9Vgd0GraFZbP4IiT7nHMlaw4H6E7Muucf7vXpGV6u7d4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.8",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.8.tgz",
@@ -8664,6 +8677,15 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/hophacks-app/package.json
+++ b/hophacks-app/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/native": "^7.1.8",
     "@supabase/supabase-js": "^2.57.4",
     "expo": "~54.0.6",
+    "expo-barcode-scanner": "~13.0.1",
     "expo-constants": "~18.0.8",
     "expo-font": "~14.0.8",
     "expo-haptics": "~15.0.7",


### PR DESCRIPTION
## Summary
- add API helpers for checking in/out of events
- introduce QR scanner modal with sign-in/out toggle
- show scan button on event cards and display attendance times
- display past event attendance in My Events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c59d9ca97883339f9691bd176266b2