### PR TITLE
feat: add app icon and loading screen

### DIFF
--- a/hophacks-app/app.json
+++ b/hophacks-app/app.json
@@ -4,7 +4,7 @@
     "slug": "hophacks-app",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
+    "icon": "./assets/images/app-icon.png",
     "scheme": "hophacksapp",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
@@ -30,7 +30,7 @@
       [
         "expo-splash-screen",
         {
-          "image": "./assets/images/splash-icon.png",
+          "image": "./assets/images/loading-screen.png",
           "imageWidth": 200,
           "resizeMode": "contain",
           "backgroundColor": "#ffffff",

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Text, View, StyleSheet, SafeAreaView, ActivityIndicator } from "react-native";
+import { View, StyleSheet, SafeAreaView } from 'react-native';
+import LoadingScreen from '../components/LoadingScreen';
 import { StatusBar } from 'expo-status-bar';
 import CustomTabBar from '../components/CustomTabBar';
 import { useTheme } from '../context/ThemeContext';
@@ -20,19 +21,10 @@ export default function Index() {
   const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   useEffect(() => {
-    console.log('Initializing app...');
     const initializeApp = async () => {
       try {
-        console.log('Initializing authentication...');
         const authSuccess = await authService.initializeAuth();
         setIsAuthenticated(authSuccess);
-        if (authSuccess) {
-          console.log('App initialized successfully');
-        } else {
-          console.log('No existing session, showing login screen');
-        }
-      } catch (error) {
-        console.log('App initialization error:', error);
       } finally {
         setIsInitializing(false);
       }
@@ -43,7 +35,6 @@ export default function Index() {
 
   const handleTabPress = (tab: string) => {
     setActiveTab(tab);
-    console.log(`Switched to ${tab} tab`);
   };
 
   const renderTabContent = () => {
@@ -64,12 +55,7 @@ export default function Index() {
   };
 
   if (isInitializing) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={styles.loadingText}>Initializing app...</Text>
-      </View>
-    );
+    return <LoadingScreen />;
   }
 
   if (!isAuthenticated) {
@@ -102,18 +88,6 @@ const createStyles = (colors: ColorScheme) =>
     },
     safeArea: {
       flex: 1,
-    },
-    loadingContainer: {
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
-      backgroundColor: colors.background,
-    },
-    loadingText: {
-      marginTop: 16,
-      fontSize: 16,
-      color: colors.textSecondary,
-      fontWeight: '500',
     },
     content: {
       flex: 1,

--- a/hophacks-app/components/LoadingScreen.tsx
+++ b/hophacks-app/components/LoadingScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Image, ActivityIndicator, StyleSheet } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+
+export default function LoadingScreen() {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Image file path: assets/images/app-icon.png */}
+      <Image source={require('../assets/images/app-icon.png')} style={styles.image} />
+      <ActivityIndicator size="large" color={colors.primary} style={styles.spinner} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  image: {
+    width: 120,
+    height: 120,
+    resizeMode: 'contain',
+  },
+  spinner: {
+    marginTop: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- reference app icon and splash image in Expo config
- introduce reusable `LoadingScreen` component that shows the app icon
- show `LoadingScreen` during initialization and remove debug logs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c59eed9d448333be0ded0d581c437e