### PR TITLE
Add QR code scanning for event attendance

### DIFF
--- a/hophacks-app/app.json
+++ b/hophacks-app/app.json
@@ -38,7 +38,8 @@
             "backgroundColor": "#000000"
           }
         }
-      ]
+      ],
+      "expo-camera"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/hophacks-app/components/Events/QRScannerModal.tsx
+++ b/hophacks-app/components/Events/QRScannerModal.tsx
@@ -17,6 +17,7 @@ const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuc
   const [permission, requestPermission] = useCameraPermissions();
   const [mode, setMode] = useState<'in' | 'out'>('in');
   const [scanned, setScanned] = useState(false);
+  const processingRef = useRef(false);
   const highlight = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -36,7 +37,8 @@ const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuc
   }, [mode, highlight]);
 
   const handleBarCodeScanned = ({ data }: BarcodeScanningResult) => {
-    if (scanned) return;
+    if (processingRef.current || scanned) return;
+    processingRef.current = true;
     setScanned(true);
     const eventId = data;
     const isSignIn = mode === 'in';
@@ -48,7 +50,10 @@ const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuc
         {
           text: 'Cancel',
           style: 'cancel',
-          onPress: () => setScanned(false),
+          onPress: () => {
+            setScanned(false);
+            processingRef.current = false;
+          },
         },
         {
           text: 'OK',
@@ -65,6 +70,7 @@ const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuc
               onSuccess && onSuccess();
             }
             onClose();
+            processingRef.current = false;
           },
         },
       ]

--- a/hophacks-app/components/Events/QRScannerModal.tsx
+++ b/hophacks-app/components/Events/QRScannerModal.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity, Animated, Alert } from 'react-native';
+import { CameraView, useCameraPermissions, BarcodeScanningResult } from 'expo-camera';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
+import { checkInToEvent, checkOutFromEvent } from '../../lib/apiService';
+
+interface QRScannerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuccess }) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const [permission, requestPermission] = useCameraPermissions();
+  const [mode, setMode] = useState<'in' | 'out'>('in');
+  const [scanned, setScanned] = useState(false);
+  const highlight = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      setScanned(false);
+      setMode('in');
+      requestPermission();
+    }
+  }, [visible, requestPermission]);
+
+  useEffect(() => {
+    Animated.timing(highlight, {
+      toValue: mode === 'in' ? 0 : 1,
+      duration: 200,
+      useNativeDriver: false,
+    }).start();
+  }, [mode, highlight]);
+
+  const handleBarCodeScanned = ({ data }: BarcodeScanningResult) => {
+    if (scanned) return;
+    setScanned(true);
+    const eventId = data;
+    const isSignIn = mode === 'in';
+
+    Alert.alert(
+      `Confirm ${isSignIn ? 'Sign In' : 'Sign Out'}`,
+      `Do you want to ${isSignIn ? 'sign in to' : 'sign out of'} this event?`,
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+          onPress: () => setScanned(false),
+        },
+        {
+          text: 'OK',
+          onPress: async () => {
+            const result = isSignIn
+              ? await checkInToEvent(eventId)
+              : await checkOutFromEvent(eventId);
+            if (result.error) {
+              console.log(result.error.message || 'Unable to update attendance');
+            } else {
+              console.log(
+                isSignIn ? 'Checked in successfully' : 'Checked out successfully'
+              );
+              onSuccess && onSuccess();
+            }
+            onClose();
+          },
+        },
+      ]
+    );
+  };
+
+  if (!permission) return null;
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        {permission.granted ? (
+          <>
+            <CameraView
+              style={StyleSheet.absoluteFillObject}
+              barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+              onBarcodeScanned={handleBarCodeScanned}
+            />
+            <View style={styles.frameContainer} pointerEvents="none">
+              <View style={styles.frame}>
+                <View style={[styles.corner, styles.topLeft]} />
+                <View style={[styles.corner, styles.topRight]} />
+                <View style={[styles.corner, styles.bottomLeft]} />
+                <View style={[styles.corner, styles.bottomRight]} />
+              </View>
+            </View>
+            <Text style={styles.instructions}>Scan the event QR code</Text>
+          </>
+        ) : (
+          <View style={styles.permissionContainer}>
+            <Text style={styles.permissionText}>Camera permission is required</Text>
+          </View>
+        )}
+        <View style={styles.controls}>
+          <View style={styles.toggleWrapper}>
+            <Animated.View
+              style={[
+                styles.toggleHighlight,
+                {
+                  left: highlight.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: ['0%', '50%'],
+                  }),
+                },
+              ]}
+            />
+            <TouchableOpacity style={styles.toggleOption} onPress={() => setMode('in')}>
+              <Text style={[styles.toggleText, mode === 'in' && styles.selectedToggleText]}>Sign In</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.toggleOption} onPress={() => setMode('out')}>
+              <Text style={[styles.toggleText, mode === 'out' && styles.selectedToggleText]}>Sign Out</Text>
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <Text style={styles.closeButtonText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default QRScannerModal;
+
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    instructions: {
+      position: 'absolute',
+      top: 60,
+      alignSelf: 'center',
+      color: colors.textWhite,
+      fontSize: 16,
+    },
+    frameContainer: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    frame: {
+      width: 250,
+      height: 250,
+    },
+    corner: {
+      position: 'absolute',
+      width: 40,
+      height: 40,
+      borderColor: colors.textWhite,
+      borderWidth: 2,
+    },
+    topLeft: { top: 0, left: 0, borderRightWidth: 0, borderBottomWidth: 0 },
+    topRight: { top: 0, right: 0, borderLeftWidth: 0, borderBottomWidth: 0 },
+    bottomLeft: { bottom: 0, left: 0, borderRightWidth: 0, borderTopWidth: 0 },
+    bottomRight: { bottom: 0, right: 0, borderLeftWidth: 0, borderTopWidth: 0 },
+    controls: {
+      position: 'absolute',
+      bottom: 40,
+      left: 0,
+      right: 0,
+      alignItems: 'center',
+    },
+    toggleWrapper: {
+      width: 200,
+      height: 40,
+      borderRadius: 8,
+      backgroundColor: colors.surface,
+      flexDirection: 'row',
+      overflow: 'hidden',
+      marginBottom: 16,
+    },
+    toggleHighlight: {
+      position: 'absolute',
+      width: '50%',
+      height: '100%',
+      backgroundColor: colors.primary,
+      borderRadius: 8,
+    },
+    toggleOption: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    toggleText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.textPrimary,
+    },
+    selectedToggleText: {
+      color: colors.textWhite,
+    },
+    closeButton: {
+      backgroundColor: colors.primary,
+      paddingVertical: 10,
+      paddingHorizontal: 20,
+      borderRadius: 8,
+    },
+    closeButtonText: {
+      color: colors.textWhite,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    permissionContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    permissionText: {
+      color: colors.textPrimary,
+    },
+  });

--- a/hophacks-app/components/MyEvents/MyEventsEventCard.tsx
+++ b/hophacks-app/components/MyEvents/MyEventsEventCard.tsx
@@ -225,7 +225,7 @@ const createStyles = (colors: ColorScheme) =>
     detailsRow: {
       flexDirection: 'row',
       justifyContent: 'space-between',
-      alignItems: 'flex-start',
+      alignItems: 'flex-end',
       marginBottom: 12,
     },
     eventDetails: {
@@ -254,5 +254,6 @@ const createStyles = (colors: ColorScheme) =>
       backgroundColor: colors.primary,
       padding: 8,
       borderRadius: 8,
+      alignSelf: 'flex-end',
     },
   });

--- a/hophacks-app/components/MyEvents/MyEventsEventCard.tsx
+++ b/hophacks-app/components/MyEvents/MyEventsEventCard.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../context/ThemeContext';
+import type { ColorScheme } from '../../constants/colors';
+
+export interface MyEventsEventCardProps {
+  id: string;
+  title: string;
+  description?: string;
+  cause: 'food_security' | 'animal_welfare' | 'environment' | 'education' | 'health' | 'community' | 'other';
+  starts_at: string;
+  ends_at: string;
+  lat?: number;
+  lng?: number;
+  capacity?: number;
+  org_name?: string;
+  distance?: string;
+  onPress?: () => void;
+  onScanPress?: () => void;
+  showScanButton?: boolean;
+  checkInTime?: string;
+  checkOutTime?: string;
+}
+
+const MyEventsEventCard: React.FC<MyEventsEventCardProps> = ({
+  id,
+  title,
+  description,
+  cause,
+  starts_at,
+  ends_at,
+  lat,
+  lng,
+  capacity,
+  org_name = 'Organization',
+  distance = 'Location TBD',
+  onPress,
+  onScanPress,
+  showScanButton = false,
+  checkInTime,
+  checkOutTime,
+}) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+  const formatEventTime = (startTime: string, endTime: string) => {
+    const start = new Date(startTime);
+    const now = new Date();
+
+    const isToday = start.toDateString() === now.toDateString();
+    const isTomorrow =
+      start.toDateString() ===
+      new Date(now.getTime() + 24 * 60 * 60 * 1000).toDateString();
+
+    let dayText = '';
+    if (isToday) dayText = 'Today';
+    else if (isTomorrow) dayText = 'Tomorrow';
+    else dayText = start.toLocaleDateString();
+
+    const timeText = start.toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    return `${dayText}, ${timeText}`;
+  };
+
+  const formatCause = (cause: string) => {
+    return cause
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  const getLocationText = () => {
+    if (lat && lng) {
+      return distance || 'Near you';
+    }
+    return distance;
+  };
+
+  const formatTimeOnly = (time: string) =>
+    new Date(time).toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+  return (
+    <TouchableOpacity
+      style={styles.eventCard}
+      onPress={onPress}
+      activeOpacity={0.8}
+    >
+      <View style={styles.eventHeader}>
+        <View style={styles.eventImageContainer}>
+          <Ionicons name="image-outline" size={32} color={colors.textSecondary} />
+        </View>
+        <View style={styles.eventInfo}>
+          <Text style={styles.eventTitle}>{title}</Text>
+          <Text style={styles.eventOrganization}>{org_name}</Text>
+        </View>
+      </View>
+
+      {description && (
+        <Text style={styles.eventDescription} numberOfLines={2}>
+          {description}
+        </Text>
+      )}
+
+      <View style={styles.detailsRow}>
+        <View style={styles.eventDetails}>
+          <View style={styles.eventDetailItem}>
+            <Ionicons
+              name="location-outline"
+              size={14}
+              color={colors.textSecondary}
+            />
+            <Text style={styles.eventDetailText}>{getLocationText()}</Text>
+          </View>
+          <View style={styles.eventDetailItem}>
+            <Ionicons
+              name="pricetag-outline"
+              size={14}
+              color={colors.textSecondary}
+            />
+            <Text style={styles.eventDetailText}>{formatCause(cause)}</Text>
+          </View>
+          {capacity && (
+            <View style={styles.eventDetailItem}>
+              <Ionicons
+                name="people-outline"
+                size={14}
+                color={colors.textSecondary}
+              />
+              <Text style={styles.eventDetailText}>Cap: {capacity}</Text>
+            </View>
+          )}
+          <View style={styles.eventDetailItem}>
+            <Ionicons name="time-outline" size={14} color={colors.textSecondary} />
+            <Text style={styles.eventDetailText}>{formatEventTime(starts_at, ends_at)}</Text>
+          </View>
+        </View>
+        {showScanButton && (
+          <TouchableOpacity
+            style={styles.scanButton}
+            onPress={onScanPress}
+            activeOpacity={0.8}
+          >
+            <Ionicons
+              name="qr-code-outline"
+              size={20}
+              color={colors.textWhite}
+            />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {(checkInTime || checkOutTime) && (
+        <View style={styles.attendanceTimes}>
+          {checkInTime && (
+            <Text style={styles.attendanceText}>
+              Sign in: {formatTimeOnly(checkInTime)}
+            </Text>
+          )}
+          {checkOutTime && (
+            <Text style={styles.attendanceText}>
+              Sign out: {formatTimeOnly(checkOutTime)}
+            </Text>
+          )}
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+export default MyEventsEventCard;
+
+const createStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    eventCard: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: 16,
+      width: '100%',
+      shadowColor: colors.shadow,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
+    },
+    eventHeader: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginBottom: 12,
+    },
+    eventImageContainer: {
+      width: 60,
+      height: 60,
+      borderRadius: 8,
+      backgroundColor: colors.borderLight || '#E5E5E5',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginRight: 12,
+    },
+    eventInfo: {
+      flex: 1,
+      justifyContent: 'flex-start',
+    },
+    eventTitle: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      marginBottom: 4,
+    },
+    eventOrganization: {
+      fontSize: 14,
+      color: colors.textSecondary,
+    },
+    eventDescription: {
+      fontSize: 13,
+      color: colors.textSecondary,
+      marginBottom: 12,
+      lineHeight: 18,
+    },
+    detailsRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: 12,
+    },
+    eventDetails: {
+      flex: 1,
+      marginRight: 12,
+    },
+    eventDetailItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    eventDetailText: {
+      fontSize: 12,
+      color: colors.textSecondary,
+      marginLeft: 6,
+    },
+    attendanceTimes: {
+      flex: 1,
+    },
+    attendanceText: {
+      fontSize: 12,
+      color: colors.warning,
+      marginBottom: 4,
+    },
+    scanButton: {
+      backgroundColor: colors.primary,
+      padding: 8,
+      borderRadius: 8,
+    },
+  });

--- a/hophacks-app/package-lock.json
+++ b/hophacks-app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.8",
         "@supabase/supabase-js": "^2.57.4",
         "expo": "~54.0.6",
+        "expo-camera": "~15.0.7",
         "expo-constants": "~18.0.8",
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
@@ -8600,6 +8601,18 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "15.0.16",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-15.0.16.tgz",
+      "integrity": "sha512-FLE02DMqkjwsb7IugKAqQvBe6s+TCQeb5LupO1+r//wAhBwmHncOrc6zV95ZEC2f9PTPK34nFH/s8CDGiVzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/hophacks-app/package.json
+++ b/hophacks-app/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/native": "^7.1.8",
     "@supabase/supabase-js": "^2.57.4",
     "expo": "~54.0.6",
+    "expo-camera": "~15.0.7",
     "expo-constants": "~18.0.8",
     "expo-font": "~14.0.8",
     "expo-haptics": "~15.0.7",


### PR DESCRIPTION
## Summary
- place QR scan button alongside event metadata and keep past attendance times in orange
- add camera framing guides and confirmation prompt before sign-in or sign-out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59d9ca97883339f9691bd176266b2