### PR TITLE
Award points on event checkout and confirm attendance

### DIFF
--- a/hophacks-app/components/Events/QRScannerModal.tsx
+++ b/hophacks-app/components/Events/QRScannerModal.tsx
@@ -64,8 +64,10 @@ const QRScannerModal: React.FC<QRScannerModalProps> = ({ visible, onClose, onSuc
             if (result.error) {
               console.log(result.error.message || 'Unable to update attendance');
             } else {
-              console.log(
-                isSignIn ? 'Checked in successfully' : 'Checked out successfully'
+              const eventTitle = result.data?.events?.title || 'event';
+              Alert.alert(
+                'Success',
+                `Successfully signed ${isSignIn ? 'in to' : 'out of'} ${eventTitle}`
               );
               onSuccess && onSuccess();
             }


### PR DESCRIPTION
## Summary
- award points on event checkout based on time attended and update ledger
- return event info on check-in/out and confirm attendance via alerts

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve path to module 'react-native-qrcode-svg'; Unable to resolve path to module 'expo-camera'; `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`; `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dc1073c883338d57a9b96224108f