### PR TITLE
Prefetch app data and keep tabs mounted

### DIFF
--- a/hophacks-app/app/(tabs)/EventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/EventsScreen.tsx
@@ -56,6 +56,8 @@ const EventsScreen = () => {
   useEffect(() => {
     if (currentUserId) {
       fetchEvents();
+      const interval = setInterval(() => fetchEvents(true), 60000);
+      return () => clearInterval(interval);
     }
   }, [currentUserId]);
 
@@ -84,16 +86,18 @@ const EventsScreen = () => {
     }
   };
 
-  const fetchEvents = async () => {
+  const fetchEvents = async (background = false) => {
     try {
-      setLoading(true);
-      setError(null);
-      
+      if (!background) {
+        setLoading(true);
+        setError(null);
+      }
+
       // Fetch events the user hasn't joined
       const { data, error } = await getUnjoinedEvents();
 
       if (error) {
-        setError(error.message || 'Failed to fetch events');
+        if (!background) setError(error.message || 'Failed to fetch events');
         return;
       }
 
@@ -124,9 +128,9 @@ const EventsScreen = () => {
         setEvents(transformedEvents);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch events');
+      if (!background) setError(err instanceof Error ? err.message : 'Failed to fetch events');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   };
 

--- a/hophacks-app/app/(tabs)/GroupsScreen.tsx
+++ b/hophacks-app/app/(tabs)/GroupsScreen.tsx
@@ -43,9 +43,9 @@ const GroupsScreen = () => {
   const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   // Load groups from database
-  const loadGroups = async () => {
+  const loadGroups = async (background = false) => {
     try {
-      setLoading(true);
+      if (!background) setLoading(true);
       const { data: groupsData, error } = await getUserGroups();
       
       if (error) {
@@ -72,18 +72,20 @@ const GroupsScreen = () => {
       console.error('Error loading groups:', error);
       Alert.alert('Error', 'Failed to load groups. Please try again.');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   };
 
   useEffect(() => {
     loadGroups();
+    const interval = setInterval(() => loadGroups(true), 60000);
+    return () => clearInterval(interval);
   }, []);
 
   // Reload groups when screen comes into focus (e.g., returning from group dashboard)
   useFocusEffect(
     React.useCallback(() => {
-      loadGroups();
+      loadGroups(true);
     }, [])
   );
 

--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -110,93 +110,95 @@ const HomeScreen = () => {
     }
   };
 
-  useEffect(() => {
-    const fetchUserAndEvents = async () => {
-      try {
-        setIsLoading(true);
+  const fetchUserAndEvents = async (background = false) => {
+    try {
+      if (!background) setIsLoading(true);
 
-        // Fetch user basic data (name only)
-        const { data: userData, error: userError } = await getUserInfoById();
-        
-        // Calculate points and streak from points_ledger
-        const { data: totalPoints, error: pointsError } = await calculateUserTotalPoints();
-        const { data: weeklyStreak, error: streakError } = await calculateUserWeeklyStreak();
-        
-        if (userError) {
-          console.log('Error fetching user:', userError);
-        } else if (userData) {
-          const calculatedPoints = totalPoints || 0;
-          const calculatedStreak = weeklyStreak || 0;
-          const tierInfo = getTierInfo(calculatedPoints);
-          
-          setUser({
-            name: userData.display_name || "Volunteer",
-            streak: calculatedStreak,
-            totalPoints: calculatedPoints,
-            currentTier: tierInfo.currentTier,
-            nextTier: tierInfo.nextTier,
-            pointsToNextTier: tierInfo.pointsToNextTier,
-            tierProgress: tierInfo.tierProgress,
-          });
-        }
-        
-        if (pointsError) {
-          console.log('Error calculating points:', pointsError);
-        }
-        if (streakError) {
-          console.log('Error calculating streak:', streakError);
-        }
+      // Fetch user basic data (name only)
+      const { data: userData, error: userError } = await getUserInfoById();
 
-        // Fetch event recommendations
-        const { data: eventsData, error: eventsError } = await getEventRecommendations();
+      // Calculate points and streak from points_ledger
+      const { data: totalPoints, error: pointsError } = await calculateUserTotalPoints();
+      const { data: weeklyStreak, error: streakError } = await calculateUserWeeklyStreak();
 
-        if (eventsError) {
-          console.log('Error fetching events:', eventsError);
-        } else if (eventsData) {
-          // Transform the data to match the expected format
-          const transformedEvents = eventsData.map((event: any) => {
-            console.log('🔍 Raw event data:', event);
-            console.log('🖼️ Event image_url (raw):', event.image_url);
-            const cleanedUrl = event.image_url ? cleanImageUrl(event.image_url) : null;
-            console.log('🧹 Event image_url (cleaned):', cleanedUrl);
-            return {
-              id: event.id,
-              title: event.title,
-              description: event.description,
-              cause: event.cause,
-              starts_at: event.starts_at,
-              ends_at: event.ends_at,
-              lat: event.lat,
-              lng: event.lng,
-              capacity: event.capacity,
-              org_name: event.organizations?.name || 'Unknown Organization',
-              distance: '-- mi away', // You might want to calculate this based on user location
-              image_url: cleanedUrl,
-            };
-          });
-          setSuggestedEvents(transformedEvents);
-        }
+      if (userError) {
+        console.log('Error fetching user:', userError);
+      } else if (userData) {
+        const calculatedPoints = totalPoints || 0;
+        const calculatedStreak = weeklyStreak || 0;
+        const tierInfo = getTierInfo(calculatedPoints);
 
-        // Fetch recent activity
-        const { data: activityData, error: activityError } = await getRecentActivity();
-        
-        if (activityError) {
-          console.log('Error fetching recent activity:', activityError);
-        } else if (activityData) {
-          console.log('Setting recent activity data:', activityData);
-          setRecentActivity(activityData);
-        } else {
-          console.log('No recent activity data received, setting empty array');
-          setRecentActivity([]);
-        }
-      } catch (error) {
-        console.log('Error in fetchUserAndEvents:', error);
-      } finally {
-        setIsLoading(false);
+        setUser({
+          name: userData.display_name || "Volunteer",
+          streak: calculatedStreak,
+          totalPoints: calculatedPoints,
+          currentTier: tierInfo.currentTier,
+          nextTier: tierInfo.nextTier,
+          pointsToNextTier: tierInfo.pointsToNextTier,
+          tierProgress: tierInfo.tierProgress,
+        });
       }
-    };
 
+      if (pointsError) {
+        console.log('Error calculating points:', pointsError);
+      }
+      if (streakError) {
+        console.log('Error calculating streak:', streakError);
+      }
+
+      // Fetch event recommendations
+      const { data: eventsData, error: eventsError } = await getEventRecommendations();
+
+      if (eventsError) {
+        console.log('Error fetching events:', eventsError);
+      } else if (eventsData) {
+        // Transform the data to match the expected format
+        const transformedEvents = eventsData.map((event: any) => {
+          console.log('🔍 Raw event data:', event);
+          console.log('🖼️ Event image_url (raw):', event.image_url);
+          const cleanedUrl = event.image_url ? cleanImageUrl(event.image_url) : null;
+          console.log('🧹 Event image_url (cleaned):', cleanedUrl);
+          return {
+            id: event.id,
+            title: event.title,
+            description: event.description,
+            cause: event.cause,
+            starts_at: event.starts_at,
+            ends_at: event.ends_at,
+            lat: event.lat,
+            lng: event.lng,
+            capacity: event.capacity,
+            org_name: event.organizations?.name || 'Unknown Organization',
+            distance: '-- mi away', // You might want to calculate this based on user location
+            image_url: cleanedUrl,
+          };
+        });
+        setSuggestedEvents(transformedEvents);
+      }
+
+      // Fetch recent activity
+      const { data: activityData, error: activityError } = await getRecentActivity();
+
+      if (activityError) {
+        console.log('Error fetching recent activity:', activityError);
+      } else if (activityData) {
+        console.log('Setting recent activity data:', activityData);
+        setRecentActivity(activityData);
+      } else {
+        console.log('No recent activity data received, setting empty array');
+        setRecentActivity([]);
+      }
+    } catch (error) {
+      console.log('Error in fetchUserAndEvents:', error);
+    } finally {
+      if (!background) setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
     fetchUserAndEvents();
+    const interval = setInterval(() => fetchUserAndEvents(true), 60000);
+    return () => clearInterval(interval);
   }, []);
 
   const handleViewAllActivity = () => {

--- a/hophacks-app/app/(tabs)/MyEventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/MyEventsScreen.tsx
@@ -28,25 +28,29 @@ const MyEventsScreen = () => {
 
   useEffect(() => {
     init();
+    const interval = setInterval(() => init(true), 60000);
+    return () => clearInterval(interval);
   }, []);
 
-  const init = async () => {
+  const init = async (background = false) => {
     const { data } = await getCurrentUserProfile();
     if (data) {
       setCurrentUserId(data.id);
     }
-    fetchJoinedEvents(data?.id);
+    fetchJoinedEvents(data?.id, background);
   };
 
-  const fetchJoinedEvents = async (userId?: string) => {
+  const fetchJoinedEvents = async (userId?: string, background = false) => {
     try {
-      setLoading(true);
-      setError(null);
+      if (!background) {
+        setLoading(true);
+        setError(null);
+      }
 
       const { data, error } = await getJoinedEvents();
 
       if (error) {
-        setError(error.message || 'Failed to fetch events');
+        if (!background) setError(error.message || 'Failed to fetch events');
         return;
       }
 
@@ -81,9 +85,9 @@ const MyEventsScreen = () => {
 
       setEventsByDate(grouped);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch events');
+      if (!background) setError(err instanceof Error ? err.message : 'Failed to fetch events');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   };
 
@@ -100,7 +104,7 @@ const MyEventsScreen = () => {
   const handleEventLeft = () => {
     closeEvent();
     // Refresh the joined events list
-    fetchJoinedEvents(currentUserId || undefined);
+    fetchJoinedEvents(currentUserId || undefined, true);
   };
 
   const formatDateLabel = (dateStr: string) => {

--- a/hophacks-app/app/(tabs)/ProfileScreen.tsx
+++ b/hophacks-app/app/(tabs)/ProfileScreen.tsx
@@ -68,10 +68,15 @@ const ProfileScreen: React.FC<ProfileScreenProps> = ({ onSignOut }) => {
 
   useEffect(() => {
     loadProfile();
-  }, []);
+    const interval = setInterval(() => {
+      if (!editMode) loadProfile(true);
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [editMode]);
 
-  const loadProfile = async () => {
+  const loadProfile = async (background = false) => {
     try {
+      if (!background) setLoading(true);
       const [profileResult, emailResult, totalPointsResult, currentStreakResult, longestStreakResult] = await Promise.all([
         getCurrentUserProfile(),
         authService.getCurrentUserEmail(),
@@ -81,7 +86,7 @@ const ProfileScreen: React.FC<ProfileScreenProps> = ({ onSignOut }) => {
       ]);
 
       if (profileResult.error) {
-        Alert.alert('Error', 'Failed to load profile');
+        if (!background) Alert.alert('Error', 'Failed to load profile');
         return;
       }
 
@@ -92,14 +97,14 @@ const ProfileScreen: React.FC<ProfileScreenProps> = ({ onSignOut }) => {
         const bioValue = profileResult.data.bio || '';
         const locationValue = profileResult.data.location || '';
         const birthDateValue = profileResult.data.birth_date || '';
-        
+
         // Set both working and original values
         setDisplayName(displayNameValue);
         setPhone(phoneValue);
         setBio(bioValue);
         setLocation(locationValue);
         setBirthDate(birthDateValue);
-        
+
         setOriginalDisplayName(displayNameValue);
         setOriginalPhone(phoneValue);
         setOriginalBio(bioValue);
@@ -123,9 +128,9 @@ const ProfileScreen: React.FC<ProfileScreenProps> = ({ onSignOut }) => {
         setCalculatedLongestStreak(longestStreakResult.data);
       }
     } catch (error) {
-      Alert.alert('Error', 'Failed to load profile');
+      if (!background) Alert.alert('Error', 'Failed to load profile');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   };
 

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -46,23 +46,6 @@ export default function Index() {
     console.log(`Switched to ${tab} tab`);
   };
 
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case 'home':
-        return <HomeScreen />;
-      case 'events':
-        return <EventsScreen />;
-      case 'myEvents':
-        return <MyEventsScreen />;
-      case 'groups':
-        return <GroupsScreen />;
-      case 'profile':
-        return <ProfileScreen onSignOut={() => setIsAuthenticated(false)} />;
-      default:
-        return <HomeScreen />;
-    }
-  };
-
   if (isInitializing) {
     return (
       <View style={styles.loadingContainer}>
@@ -87,7 +70,23 @@ export default function Index() {
     <View style={styles.container}>
       <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.background} />
       <SafeAreaView style={styles.safeArea}>
-        {renderTabContent()}
+        <View style={styles.screenContainer}>
+          <View style={[styles.tabView, activeTab !== 'home' && styles.hidden]}>
+            <HomeScreen />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'events' && styles.hidden]}>
+            <EventsScreen />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'myEvents' && styles.hidden]}>
+            <MyEventsScreen />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'groups' && styles.hidden]}>
+            <GroupsScreen />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'profile' && styles.hidden]}>
+            <ProfileScreen onSignOut={() => setIsAuthenticated(false)} />
+          </View>
+        </View>
       </SafeAreaView>
       <CustomTabBar activeTab={activeTab} onTabPress={handleTabPress} />
     </View>
@@ -102,6 +101,15 @@ const createStyles = (colors: ColorScheme) =>
     },
     safeArea: {
       flex: 1,
+    },
+    screenContainer: {
+      flex: 1,
+    },
+    tabView: {
+      flex: 1,
+    },
+    hidden: {
+      display: 'none',
     },
     loadingContainer: {
       flex: 1,


### PR DESCRIPTION
## Summary
- Keep all tab screens mounted to retain state and preload content after login
- Added background refresh intervals for Home, Events, My Events, Groups, and Profile tabs to update data without blocking interaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c63442339c83338be0eec8e6c6360d