### PR TITLE
feat: display user avatar on home screen

### DIFF
--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -11,6 +11,7 @@ import {
   LayoutAnimation,
   Platform,
   UIManager,
+  Image,
 } from 'react-native'
 import React, { useState, useEffect, useRef } from 'react'
 import { useTheme } from '../../context/ThemeContext';
@@ -22,11 +23,23 @@ import { authService } from '../../lib/authService';
 import { router } from 'expo-router';
 import SpecificEventPage from '../../components/SpecificEventPage';
 
+type UserProfile = {
+  name: string;
+  avatarUrl: string | null;
+  streak: number;
+  totalPoints: number;
+  currentTier: string;
+  nextTier: string;
+  pointsToNextTier: number;
+  tierProgress: number;
+};
+
 const HomeScreen = () => {
   // Mock data - replace with real data later
 
-  const [user, setUser] = useState({
+  const [user, setUser] = useState<UserProfile>({
     name: "Alex Johnson", // fallback name
+    avatarUrl: null,
     streak: 0,
     totalPoints: 0,
     currentTier: "New Volunteer",
@@ -130,6 +143,7 @@ const HomeScreen = () => {
 
         setUser({
           name: userData.display_name || "Volunteer",
+          avatarUrl: userData.avatar_url,
           streak: calculatedStreak,
           totalPoints: calculatedPoints,
           currentTier: tierInfo.currentTier,
@@ -262,11 +276,15 @@ const HomeScreen = () => {
     <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
       {/* Profile Widget */}
       <View style={styles.profileWidget}>
-        <View style={styles.profileIcon}>
-          <Text style={styles.profileIconText}>
-            {user.name.charAt(0).toUpperCase()}
-          </Text>
-        </View>
+        {user.avatarUrl ? (
+          <Image source={{ uri: user.avatarUrl }} style={styles.profileImage} />
+        ) : (
+          <View style={styles.profileIcon}>
+            <Text style={styles.profileIconText}>
+              {user.name.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
         <View style={styles.profileInfo}>
           <Text style={styles.userName}>{user.name}</Text>
           <View style={styles.streakContainer}>
@@ -436,6 +454,12 @@ const createStyles = (colors: ColorScheme) => StyleSheet.create({
     backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
+    marginRight: 20,
+  },
+  profileImage: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
     marginRight: 20,
   },
   profileIconText: {


### PR DESCRIPTION
## Summary
- allow avatar URL to render profile picture on home screen
- fall back to initial-based icon when no avatar URL is set

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve path to module 'react-native-qrcode-svg', Unable to resolve path to module 'expo-camera', `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`, `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`)*

------
https://chatgpt.com/codex/tasks/task_e_68c63f5889e483338d7a0c6fc8e49cf4