### PR TITLE
Prefetch app data, keep tabs mounted, and add pull-to-refresh

### DIFF
--- a/hophacks-app/app/(tabs)/EventsScreen.tsx
+++ b/hophacks-app/app/(tabs)/EventsScreen.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  RefreshControl,
   ActivityIndicator,
   Animated,
   Dimensions,
@@ -27,7 +28,11 @@ interface Event extends EventsEventCardProps {
   image_url?: string | null;
 }
 
-const EventsScreen = () => {
+interface EventsScreenProps {
+  isActive: boolean;
+}
+
+const EventsScreen: React.FC<EventsScreenProps> = ({ isActive }) => {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +43,7 @@ const EventsScreen = () => {
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [qrVisible, setQrVisible] = useState(false);
   const [qrEventId, setQrEventId] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
   const animations = useRef<Record<string, { slide: Animated.Value; bubble: Animated.Value }>>({});
   const { colors } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
@@ -56,8 +62,16 @@ const EventsScreen = () => {
   useEffect(() => {
     if (currentUserId) {
       fetchEvents();
+      const interval = setInterval(() => fetchEvents(true), 60000);
+      return () => clearInterval(interval);
     }
   }, [currentUserId]);
+
+  useEffect(() => {
+    if (isActive) {
+      fetchEvents(true);
+    }
+  }, [isActive]);
 
   // Helper function to clean image URLs
   const cleanImageUrl = (url: string) => {
@@ -84,16 +98,18 @@ const EventsScreen = () => {
     }
   };
 
-  const fetchEvents = async () => {
+  const fetchEvents = async (background = false) => {
     try {
-      setLoading(true);
-      setError(null);
-      
+      if (!background) {
+        setLoading(true);
+        setError(null);
+      }
+
       // Fetch events the user hasn't joined
       const { data, error } = await getUnjoinedEvents();
 
       if (error) {
-        setError(error.message || 'Failed to fetch events');
+        if (!background) setError(error.message || 'Failed to fetch events');
         return;
       }
 
@@ -124,10 +140,16 @@ const EventsScreen = () => {
         setEvents(transformedEvents);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch events');
+      if (!background) setError(err instanceof Error ? err.message : 'Failed to fetch events');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
+  };
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchEvents(true);
+    setRefreshing(false);
   };
 
   const openEvent = (id: string) => {
@@ -188,15 +210,36 @@ const EventsScreen = () => {
 
   if (error) {
     return (
-      <View style={styles.centerContainer}>
-        <Text style={styles.errorText}>Error: {error}</Text>
-      </View>
+      <ScrollView
+        style={styles.container}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.primary}
+          />
+        }
+      >
+        <View style={styles.centerContainer}>
+          <Text style={styles.errorText}>Error: {error}</Text>
+        </View>
+      </ScrollView>
     );
   }
 
   return (
     <>
-      <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.container}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.primary}
+          />
+        }
+      >
         <View style={styles.header}>
           <Text style={styles.title}>All Events</Text>
           <Text style={styles.subtitle}>Find volunteering opportunities near you</Text>

--- a/hophacks-app/app/(tabs)/GroupsScreen.tsx
+++ b/hophacks-app/app/(tabs)/GroupsScreen.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  RefreshControl,
   TouchableOpacity,
   ActivityIndicator,
   Alert,
@@ -33,19 +34,24 @@ interface GroupSummary {
   };
 }
 
-const GroupsScreen = () => {
+interface GroupsScreenProps {
+  isActive: boolean;
+}
+
+const GroupsScreen: React.FC<GroupsScreenProps> = ({ isActive }) => {
   const [groups, setGroups] = useState<GroupSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [createdGroup, setCreatedGroup] = useState<any>(null);
+  const [refreshing, setRefreshing] = useState(false);
   const { colors, theme } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   // Load groups from database
-  const loadGroups = async () => {
+  const loadGroups = async (background = false) => {
     try {
-      setLoading(true);
+      if (!background) setLoading(true);
       const { data: groupsData, error } = await getUserGroups();
       
       if (error) {
@@ -72,18 +78,32 @@ const GroupsScreen = () => {
       console.error('Error loading groups:', error);
       Alert.alert('Error', 'Failed to load groups. Please try again.');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
+  };
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadGroups(true);
+    setRefreshing(false);
   };
 
   useEffect(() => {
     loadGroups();
+    const interval = setInterval(() => loadGroups(true), 60000);
+    return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (isActive) {
+      loadGroups(true);
+    }
+  }, [isActive]);
 
   // Reload groups when screen comes into focus (e.g., returning from group dashboard)
   useFocusEffect(
     React.useCallback(() => {
-      loadGroups();
+      loadGroups(true);
     }, [])
   );
 
@@ -177,24 +197,46 @@ const GroupsScreen = () => {
 
   if (groups.length === 0) {
     return (
-      <View style={styles.emptyContainer}>
-        <Ionicons name="people-outline" size={64} color={colors.textSecondary} />
-        <Text style={styles.emptyTitle}>No Groups Yet</Text>
-        <Text style={styles.emptySubtitle}>Join or create a group to start competing with friends!</Text>
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.createGroupButton} onPress={handleCreateGroup}>
-            <Text style={styles.createGroupButtonText}>Create Group</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.joinGroupButton} onPress={handleJoinGroup}>
-            <Text style={styles.joinGroupButtonText}>Join Group</Text>
-          </TouchableOpacity>
+      <ScrollView
+        style={styles.container}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.primary}
+          />
+        }
+      >
+        <View style={styles.emptyContainer}>
+          <Ionicons name="people-outline" size={64} color={colors.textSecondary} />
+          <Text style={styles.emptyTitle}>No Groups Yet</Text>
+          <Text style={styles.emptySubtitle}>Join or create a group to start competing with friends!</Text>
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.createGroupButton} onPress={handleCreateGroup}>
+              <Text style={styles.createGroupButtonText}>Create Group</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.joinGroupButton} onPress={handleJoinGroup}>
+              <Text style={styles.joinGroupButtonText}>Join Group</Text>
+            </TouchableOpacity>
+          </View>
         </View>
-      </View>
+      </ScrollView>
     );
   }
 
   return (
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={styles.container}
+      showsVerticalScrollIndicator={false}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor={colors.primary}
+        />
+      }
+    >
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.headerTitle}>My Groups</Text>

--- a/hophacks-app/app/(tabs)/HomeScreen.tsx
+++ b/hophacks-app/app/(tabs)/HomeScreen.tsx
@@ -3,6 +3,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  RefreshControl,
   TouchableOpacity,
   Alert,
   ActivityIndicator,
@@ -22,7 +23,11 @@ import { authService } from '../../lib/authService';
 import { router } from 'expo-router';
 import SpecificEventPage from '../../components/SpecificEventPage';
 
-const HomeScreen = () => {
+interface HomeScreenProps {
+  isActive: boolean;
+}
+
+const HomeScreen: React.FC<HomeScreenProps> = ({ isActive }) => {
   // Mock data - replace with real data later
 
   const [user, setUser] = useState({
@@ -37,6 +42,7 @@ const HomeScreen = () => {
   const [suggestedEvents, setSuggestedEvents] = useState<any[]>([]);
   const [recentActivity, setRecentActivity] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
     const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
     const [eventPageVisible, setEventPageVisible] = useState(false);
     const animations = useRef<Record<string, { slide: Animated.Value; bubble: Animated.Value }>>({});
@@ -110,94 +116,108 @@ const HomeScreen = () => {
     }
   };
 
-  useEffect(() => {
-    const fetchUserAndEvents = async () => {
-      try {
-        setIsLoading(true);
+  const fetchUserAndEvents = async (background = false) => {
+    try {
+      if (!background) setIsLoading(true);
 
-        // Fetch user basic data (name only)
-        const { data: userData, error: userError } = await getUserInfoById();
-        
-        // Calculate points and streak from points_ledger
-        const { data: totalPoints, error: pointsError } = await calculateUserTotalPoints();
-        const { data: weeklyStreak, error: streakError } = await calculateUserWeeklyStreak();
-        
-        if (userError) {
-          console.log('Error fetching user:', userError);
-        } else if (userData) {
-          const calculatedPoints = totalPoints || 0;
-          const calculatedStreak = weeklyStreak || 0;
-          const tierInfo = getTierInfo(calculatedPoints);
-          
-          setUser({
-            name: userData.display_name || "Volunteer",
-            streak: calculatedStreak,
-            totalPoints: calculatedPoints,
-            currentTier: tierInfo.currentTier,
-            nextTier: tierInfo.nextTier,
-            pointsToNextTier: tierInfo.pointsToNextTier,
-            tierProgress: tierInfo.tierProgress,
-          });
-        }
-        
-        if (pointsError) {
-          console.log('Error calculating points:', pointsError);
-        }
-        if (streakError) {
-          console.log('Error calculating streak:', streakError);
-        }
+      // Fetch user basic data (name only)
+      const { data: userData, error: userError } = await getUserInfoById();
 
-        // Fetch event recommendations
-        const { data: eventsData, error: eventsError } = await getEventRecommendations();
+      // Calculate points and streak from points_ledger
+      const { data: totalPoints, error: pointsError } = await calculateUserTotalPoints();
+      const { data: weeklyStreak, error: streakError } = await calculateUserWeeklyStreak();
 
-        if (eventsError) {
-          console.log('Error fetching events:', eventsError);
-        } else if (eventsData) {
-          // Transform the data to match the expected format
-          const transformedEvents = eventsData.map((event: any) => {
-            console.log('🔍 Raw event data:', event);
-            console.log('🖼️ Event image_url (raw):', event.image_url);
-            const cleanedUrl = event.image_url ? cleanImageUrl(event.image_url) : null;
-            console.log('🧹 Event image_url (cleaned):', cleanedUrl);
-            return {
-              id: event.id,
-              title: event.title,
-              description: event.description,
-              cause: event.cause,
-              starts_at: event.starts_at,
-              ends_at: event.ends_at,
-              lat: event.lat,
-              lng: event.lng,
-              capacity: event.capacity,
-              org_name: event.organizations?.name || 'Unknown Organization',
-              distance: '-- mi away', // You might want to calculate this based on user location
-              image_url: cleanedUrl,
-            };
-          });
-          setSuggestedEvents(transformedEvents);
-        }
+      if (userError) {
+        console.log('Error fetching user:', userError);
+      } else if (userData) {
+        const calculatedPoints = totalPoints || 0;
+        const calculatedStreak = weeklyStreak || 0;
+        const tierInfo = getTierInfo(calculatedPoints);
 
-        // Fetch recent activity
-        const { data: activityData, error: activityError } = await getRecentActivity();
-        
-        if (activityError) {
-          console.log('Error fetching recent activity:', activityError);
-        } else if (activityData) {
-          console.log('Setting recent activity data:', activityData);
-          setRecentActivity(activityData);
-        } else {
-          console.log('No recent activity data received, setting empty array');
-          setRecentActivity([]);
-        }
-      } catch (error) {
-        console.log('Error in fetchUserAndEvents:', error);
-      } finally {
-        setIsLoading(false);
+        setUser({
+          name: userData.display_name || "Volunteer",
+          streak: calculatedStreak,
+          totalPoints: calculatedPoints,
+          currentTier: tierInfo.currentTier,
+          nextTier: tierInfo.nextTier,
+          pointsToNextTier: tierInfo.pointsToNextTier,
+          tierProgress: tierInfo.tierProgress,
+        });
       }
-    };
 
+      if (pointsError) {
+        console.log('Error calculating points:', pointsError);
+      }
+      if (streakError) {
+        console.log('Error calculating streak:', streakError);
+      }
+
+      // Fetch event recommendations
+      const { data: eventsData, error: eventsError } = await getEventRecommendations();
+
+      if (eventsError) {
+        console.log('Error fetching events:', eventsError);
+      } else if (eventsData) {
+        // Transform the data to match the expected format
+        const transformedEvents = eventsData.map((event: any) => {
+          console.log('🔍 Raw event data:', event);
+          console.log('🖼️ Event image_url (raw):', event.image_url);
+          const cleanedUrl = event.image_url ? cleanImageUrl(event.image_url) : null;
+          console.log('🧹 Event image_url (cleaned):', cleanedUrl);
+          return {
+            id: event.id,
+            title: event.title,
+            description: event.description,
+            cause: event.cause,
+            starts_at: event.starts_at,
+            ends_at: event.ends_at,
+            lat: event.lat,
+            lng: event.lng,
+            capacity: event.capacity,
+            org_name: event.organizations?.name || 'Unknown Organization',
+            distance: '-- mi away', // You might want to calculate this based on user location
+            image_url: cleanedUrl,
+          };
+        });
+        setSuggestedEvents(transformedEvents);
+      }
+
+      // Fetch recent activity
+      const { data: activityData, error: activityError } = await getRecentActivity();
+
+      if (activityError) {
+        console.log('Error fetching recent activity:', activityError);
+      } else if (activityData) {
+        console.log('Setting recent activity data:', activityData);
+        setRecentActivity(activityData);
+      } else {
+        console.log('No recent activity data received, setting empty array');
+        setRecentActivity([]);
+      }
+    } catch (error) {
+      console.log('Error in fetchUserAndEvents:', error);
+    } finally {
+      if (!background) setIsLoading(false);
+    }
+  };
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchUserAndEvents(true);
+    setRefreshing(false);
+  };
+
+  useEffect(() => {
     fetchUserAndEvents();
+    const interval = setInterval(() => fetchUserAndEvents(true), 60000);
+    return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (isActive) {
+      fetchUserAndEvents(true);
+    }
+  }, [isActive]);
 
   const handleViewAllActivity = () => {
     router.push('/activity-feed?userId=current');
@@ -257,7 +277,17 @@ const HomeScreen = () => {
 
   return (
     <>
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={styles.container}
+      showsVerticalScrollIndicator={false}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor={colors.primary}
+        />
+      }
+    >
       {/* Profile Widget */}
       <View style={styles.profileWidget}>
         <View style={styles.profileIcon}>

--- a/hophacks-app/app/index.tsx
+++ b/hophacks-app/app/index.tsx
@@ -46,23 +46,6 @@ export default function Index() {
     console.log(`Switched to ${tab} tab`);
   };
 
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case 'home':
-        return <HomeScreen />;
-      case 'events':
-        return <EventsScreen />;
-      case 'myEvents':
-        return <MyEventsScreen />;
-      case 'groups':
-        return <GroupsScreen />;
-      case 'profile':
-        return <ProfileScreen onSignOut={() => setIsAuthenticated(false)} />;
-      default:
-        return <HomeScreen />;
-    }
-  };
-
   if (isInitializing) {
     return (
       <View style={styles.loadingContainer}>
@@ -87,7 +70,26 @@ export default function Index() {
     <View style={styles.container}>
       <StatusBar style={theme === 'dark' ? 'light' : 'dark'} backgroundColor={colors.background} />
       <SafeAreaView style={styles.safeArea}>
-        {renderTabContent()}
+        <View style={styles.screenContainer}>
+          <View style={[styles.tabView, activeTab !== 'home' && styles.hidden]}>
+            <HomeScreen isActive={activeTab === 'home'} />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'events' && styles.hidden]}>
+            <EventsScreen isActive={activeTab === 'events'} />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'myEvents' && styles.hidden]}>
+            <MyEventsScreen isActive={activeTab === 'myEvents'} />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'groups' && styles.hidden]}>
+            <GroupsScreen isActive={activeTab === 'groups'} />
+          </View>
+          <View style={[styles.tabView, activeTab !== 'profile' && styles.hidden]}>
+            <ProfileScreen
+              onSignOut={() => setIsAuthenticated(false)}
+              isActive={activeTab === 'profile'}
+            />
+          </View>
+        </View>
       </SafeAreaView>
       <CustomTabBar activeTab={activeTab} onTabPress={handleTabPress} />
     </View>
@@ -102,6 +104,15 @@ const createStyles = (colors: ColorScheme) =>
     },
     safeArea: {
       flex: 1,
+    },
+    screenContainer: {
+      flex: 1,
+    },
+    tabView: {
+      flex: 1,
+    },
+    hidden: {
+      display: 'none',
     },
     loadingContainer: {
       flex: 1,


### PR DESCRIPTION
## Summary
- Pass active state from the tab layout to each screen
- Refresh Home, Events, My Events, Groups, and Profile data in the background when their tab becomes active
- Allow swipe-down pull-to-refresh on all main tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c63442339c83338be0eec8e6c6360d